### PR TITLE
Blur active icon before marquee selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -109,6 +109,10 @@ tick(); setInterval(tick, 1000);
   desktop.addEventListener('mousedown', (e)=>{
     if(e.button!==0) return;
     if(e.target.closest('.icon, .window, .sticky-note, .taskbar, #startMenu')) return;
+    const active = document.activeElement;
+    if(active && active.classList && active.classList.contains('icon')){
+      active.blur();
+    }
     dragging=true; startX=e.clientX; startY=e.clientY;
     if(!e.shiftKey) document.querySelectorAll('.icon.selected').forEach(i=>i.classList.remove('selected'));
     marquee.style.left=startX+'px'; marquee.style.top=startY+'px'; marquee.style.width='0px'; marquee.style.height='0px'; marquee.style.display='block';


### PR DESCRIPTION
## Summary
- blur the currently focused desktop icon when starting a marquee drag on the empty wallpaper
- preserve shift multi-select logic while clearing single-click focus outlines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9deea764c8322a7b8192ff6817305