### PR TITLE
Prevent touch scrolling during icon drags

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,6 +77,7 @@ document.querySelectorAll('.icon').forEach(icon => {
     dragging=true;
     moved=false;
     icon.style.zIndex=1000;
+    icon.style.touchAction='none';
     cancelTimer();
     icon.setPointerCapture?.(pointerId);
   };
@@ -93,6 +94,7 @@ document.querySelectorAll('.icon').forEach(icon => {
     }
     dragging=false;
     pointerId=null;
+    icon.style.touchAction='';
   };
   const mv = (e)=>{
     if(!dragging || e.pointerId!==pointerId) return;

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,10 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 .wallpaper{position:absolute; inset:0; background:var(--desk);}
 
 /* Desktop icons */
+.desktop, .icon {
+  touch-action:none;
+}
+
 .icon {
   position:absolute;
   width:80px;


### PR DESCRIPTION
## Summary
- disable touch scrolling on the desktop surface and icons to prevent accidental page panning during drag gestures
- force icons to opt out of touch scrolling while a drag is active and restore their default behavior when it ends

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e68121c88322918521eccbb35419