### PR TITLE
Switch window dragging to pointer events

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,61 +14,53 @@ function makeWindow({title, tpl, x=140, y=90, w=420}){
 
   // titlebar drag
   const bar = node.querySelector('.titlebar');
-  let dragging=false, offX=0, offY=0, pointerId=null, longPressTimer=null;
-  const cancelTimer = () => {
-    if(longPressTimer){
-      clearTimeout(longPressTimer);
-      longPressTimer=null;
-    }
-  };
-  const startDrag = () => {
-    if(dragging || pointerId===null) return;
-    dragging=true;
-    cancelTimer();
-    bringToFront(node);
-    bar.style.touchAction='none';
-    bar.setPointerCapture?.(pointerId);
-  };
-  const endDrag = (e) => {
+  let pointerId=null, offX=0, offY=0;
+
+  function onMove(e){
     if(e.pointerId!==pointerId) return;
-    cancelTimer();
-    if(bar.hasPointerCapture?.(pointerId)){
-      bar.releasePointerCapture(pointerId);
-    }
-    dragging=false;
-    pointerId=null;
-    bar.style.touchAction='';
-  };
-  const move=(e)=>{
-    if(!dragging || e.pointerId!==pointerId) return;
     node.style.left = Math.max(0, e.clientX-offX)+'px';
     node.style.top = Math.max(0, e.clientY-offY)+'px';
-  };
+  }
+
+  function onUp(e){
+    if(e.pointerId!==pointerId) return;
+    cleanup();
+  }
+
+  function onCancel(e){
+    if(e.pointerId!==pointerId) return;
+    cleanup();
+  }
+
+  function cleanup(){
+    if(pointerId===null) return;
+    const id = pointerId;
+    pointerId=null;
+    if(bar.hasPointerCapture?.(id)){
+      bar.releasePointerCapture(id);
+    }
+    bar.removeEventListener('pointermove', onMove);
+    bar.removeEventListener('pointerup', onUp);
+    bar.removeEventListener('pointercancel', onCancel);
+    bar.style.touchAction='';
+  }
+
   bar.addEventListener('pointerdown', e=>{
     if(e.pointerType==='mouse' && e.button!==0) return;
     if(pointerId!==null) return;
     pointerId=e.pointerId;
+    bringToFront(node);
     offX=e.clientX-node.offsetLeft;
     offY=e.clientY-node.offsetTop;
-    if(e.pointerType==='mouse'){
-      e.preventDefault();
-      startDrag();
-    } else {
-      cancelTimer();
-      longPressTimer=setTimeout(()=>{
-        if(pointerId===e.pointerId) startDrag();
-      }, 300);
-    }
+    bar.style.touchAction='none';
+    bar.addEventListener('pointermove', onMove);
+    bar.addEventListener('pointerup', onUp);
+    bar.addEventListener('pointercancel', onCancel);
+    bar.setPointerCapture?.(pointerId);
+    e.preventDefault();
   });
-  bar.addEventListener('pointermove', move);
-  bar.addEventListener('pointerup', e=>{ endDrag(e); });
-  bar.addEventListener('pointercancel', e=>{ endDrag(e); });
-  bar.addEventListener('lostpointercapture', ()=>{
-    cancelTimer();
-    dragging=false;
-    pointerId=null;
-    bar.style.touchAction='';
-  });
+
+  bar.addEventListener('lostpointercapture', cleanup);
 
   // controls
   node.querySelector('.btn-close').addEventListener('click', ()=> { node.remove(); tb.remove(); });
@@ -87,7 +79,7 @@ function makeWindow({title, tpl, x=140, y=90, w=420}){
   const tb = document.createElement('button'); tb.className='btn task-btn'; tb.textContent=title; tasks.appendChild(tb);
   tb.addEventListener('click', ()=>{ if(node.style.display==='none'){ node.style.display='block'; bringToFront(node);} else { node.style.display='none'; } });
 
-  node.addEventListener('mousedown', ()=> bringToFront(node));
+  node.addEventListener('pointerdown', ()=> bringToFront(node));
   return node;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -63,7 +63,7 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 
 /* Windows */
 .window{position:absolute; min-width:320px; min-height:160px; max-width:min(90vw, 900px); max-height:calc(100vh - 80px); background:var(--win); border:2px solid var(--dark); box-shadow:4px 4px 0 var(--darker); border-top-color:var(--light); border-left-color:var(--light); border-right-color:var(--dark); border-bottom-color:var(--dark); resize: both; overflow: auto}
-.titlebar{display:flex; align-items:center; justify-content:space-between; padding:2px 6px; background:var(--titlebar); color:var(--titletext); cursor:move}
+.titlebar{display:flex; align-items:center; justify-content:space-between; padding:2px 6px; background:var(--titlebar); color:var(--titletext); cursor:move; touch-action:none}
 .titlebar.inactive{background:var(--titlebar-inactive)}
 .titlebar .title{display:flex; align-items:center; gap:6px}
 .titlebar .controls{display:flex; gap:2px}


### PR DESCRIPTION
## Summary
- prevent the titlebar from triggering browser touch panning by disabling touch actions
- update window dragging to use pointer events with pointer capture and proper cleanup
- ensure window focus uses pointer events so taps raise the window

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9ed70f0f88322ae383d63add739f9