### PR TITLE
Ensure desktop icons drop behind windows after drag

### DIFF
--- a/script.js
+++ b/script.js
@@ -138,6 +138,7 @@ document.querySelectorAll('.icon').forEach(icon => {
     dragging=false;
     pointerId=null;
     icon.style.touchAction='';
+    icon.style.zIndex='';
   };
   const mv = (e)=>{
     if(!dragging || e.pointerId!==pointerId) return;
@@ -178,7 +179,13 @@ document.querySelectorAll('.icon').forEach(icon => {
   icon.addEventListener('pointerup', e=>{ if(e.pointerId===pointerId) endDrag(); });
   icon.addEventListener('pointercancel', e=>{ if(e.pointerId===pointerId) endDrag(); });
 
-  icon.addEventListener('lostpointercapture', ()=>{ dragging=false; pointerId=null; cancelTimer(); });
+  icon.addEventListener('lostpointercapture', ()=>{
+    dragging=false;
+    pointerId=null;
+    cancelTimer();
+    icon.style.zIndex='';
+    icon.style.touchAction='';
+  });
   icon.addEventListener('dblclick', e=>{
     if(moved) return;
     if(icon.classList.contains('sticky')){ createNote(); return; }


### PR DESCRIPTION
## Summary
- reset desktop icon z-index when their drag ends so they no longer stay above windows
- restore z-index and touch-action state when pointer capture is lost during cancellation

## Testing
- Manual verification: double-clicked an icon to open a window, dragged the icon, and confirmed it drops behind the window after releasing the pointer

------
https://chatgpt.com/codex/tasks/task_e_68d9f0d610cc8322a411f7b01468e50e