### PR TITLE
Prevent titlebar drags from control buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,6 +46,7 @@ function makeWindow({title, tpl, x=140, y=90, w=420}){
   }
 
   bar.addEventListener('pointerdown', e=>{
+    if(e.target.closest('.controls')) return;
     if(e.pointerType==='mouse' && e.button!==0) return;
     if(pointerId!==null) return;
     pointerId=e.pointerId;


### PR DESCRIPTION
## Summary
- ignore pointerdown events that originate from window control buttons so they can be clicked without starting a drag

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9f5e6c4b48322a589f8c1c151d494