### PR TITLE
Keep About blurb visible alongside tab panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,14 +98,36 @@
 <template id="tpl-about">
   <section class="content-section about" aria-labelledby="about-heading">
     <h2 id="about-heading">Instrumental Music for Media Composer</h2>
-    <p>Samuel Witt crafts vibrant, story-driven tracks for games, films, and experiential media. Each project begins with a collaborat
-ive deep dive to define tone, instrumentation, and the emotional story the music needs to support.</p>
-    <p>Currently working in his studio creating tracks for music libraries, independant artists, and production companies.</p>
-    <ul>
-      <li><strong>Expertise:</strong> Jazz/Funk, Electro Swing</li>
-      <li><strong>Toolbox:</strong> Logic Pro, Native Instruments, M2 Macbook, Adam A7x Monitors, a suite of top tier Virtual Instruments</li>
-      <li><strong>Approach:</strong> Communicative, First Principaled, Deep Context Listening.</li>
-    </ul>
+    <div class="about-blurb">
+      <p>Samuel Witt crafts vibrant, story-driven tracks for games, films, and experiential media. Each project begins with a collaborative deep dive to define tone, instrumentation, and the emotional story the music needs to support.</p>
+      <p>Currently working in his studio creating tracks for music libraries, independant artists, and production companies.</p>
+      <ul>
+        <li><strong>Expertise:</strong> Jazz/Funk, Electro Swing</li>
+        <li><strong>Toolbox:</strong> Logic Pro, Native Instruments, M2 Macbook, Adam A7x Monitors, a suite of top tier Virtual Instruments</li>
+        <li><strong>Approach:</strong> Communicative, First Principaled, Deep Context Listening.</li>
+      </ul>
+    </div>
+    <div class="about-columns">
+      <div class="about-options" role="tablist" aria-orientation="vertical">
+        <button class="about-option is-active" role="tab" id="about-option-origins" type="button" data-option="origins" aria-controls="about-panel-origins" aria-selected="true" aria-expanded="true">Origins</button>
+        <button class="about-option" role="tab" id="about-option-schooling" type="button" data-option="schooling" aria-controls="about-panel-schooling" aria-selected="false" aria-expanded="false">Schooling</button>
+        <button class="about-option" role="tab" id="about-option-career" type="button" data-option="career" aria-controls="about-panel-career" aria-selected="false" aria-expanded="false">Career</button>
+      </div>
+      <div class="about-panels">
+        <div class="about-panel is-active" id="about-panel-origins" data-option="origins" role="tabpanel" aria-labelledby="about-option-origins">
+          <p>Samuel's musical world started with a second-hand keyboard, weekend jazz records, and a curiosity for how stories sound. Those early experiments grew into arranging tunes for local theater groups and scoring friends' film projects.</p>
+          <p>Today he still chases that sense of discovery, layering organic performances with modern production touches to build immersive, character-driven soundscapes.</p>
+        </div>
+        <div class="about-panel" id="about-panel-schooling" data-option="schooling" role="tabpanel" aria-labelledby="about-option-schooling" hidden>
+          <p>Formal studies in theory, composition, and audio engineering gave Samuel a deep toolkit for sculpting tone and harmony.</p>
+          <p>Workshops with orchestrators and mix engineers continue to sharpen his ear for detail, and he regularly mentors emerging composers on arrangement fundamentals.</p>
+        </div>
+        <div class="about-panel" id="about-panel-career" data-option="career" role="tabpanel" aria-labelledby="about-option-career" hidden>
+          <p>Samuel partners with indie studios, agencies, and production collectives to craft music that supports gameplay, broadcast, and experiential work.</p>
+          <p>Recent projects span adaptive game scores, podcast sound design, and bespoke cues for installations—each with a collaborative process that keeps story front and center.</p>
+        </div>
+      </div>
+    </div>
   </section>
 </template>
 
@@ -144,13 +166,80 @@ ive deep dive to define tone, instrumentation, and the emotional story the music
 <template id="tpl-publishers">
   <section class="content-section publishers" aria-labelledby="publishers-heading">
     <h2 id="publishers-heading">Publishers &amp; Libraries</h2>
-    <p>Samuel&apos;s catalog is represented by select publishers and curated libraries for sync licensing.</p>
-    <ul>
-      <li><strong>Atlas Audio Library</strong> &mdash; electronic and hybrid orchestral collections.</li>
-      <li><strong>Rosewood Scores</strong> &mdash; bespoke film and television placements.</li>
-      <li><strong>Pulse Sync</strong> &mdash; trailer-ready cues with flexible licensing options.</li>
-    </ul>
-    <p>For clearance details or custom requests, reach out via the contact window.</p>
+    <p class="publishers-intro">Samuel&apos;s catalog is represented by select publishers and curated libraries for sync licensing. Choose a partner to see a snapshot of their catalog focus and collaboration highlights.</p>
+    <div class="publisher-columns">
+      <div class="publisher-options" role="tablist" aria-orientation="vertical">
+        <button class="publisher-option is-active" role="tab" id="publisher-option-atlas" type="button" data-option="atlas" aria-controls="publisher-panel-atlas" aria-selected="true" aria-expanded="true">Atlas Audio Library</button>
+        <button class="publisher-option" role="tab" id="publisher-option-rosewood" type="button" data-option="rosewood" aria-controls="publisher-panel-rosewood" aria-selected="false" aria-expanded="false">Rosewood Scores</button>
+        <button class="publisher-option" role="tab" id="publisher-option-pulse" type="button" data-option="pulse" aria-controls="publisher-panel-pulse" aria-selected="false" aria-expanded="false">Pulse Sync</button>
+      </div>
+      <div class="publisher-panels">
+        <div class="publisher-panel is-active" id="publisher-panel-atlas" data-option="atlas" role="tabpanel" aria-labelledby="publisher-option-atlas">
+          <figure class="publisher-hero">
+            <div class="publisher-logo" role="img" aria-label="Atlas Audio Library placeholder logo">
+              <svg viewBox="0 0 96 96" aria-hidden="true" focusable="false">
+                <defs>
+                  <linearGradient id="atlas-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                    <stop offset="0%" stop-color="#233979" />
+                    <stop offset="100%" stop-color="#5f8bd4" />
+                  </linearGradient>
+                </defs>
+                <rect x="4" y="4" width="88" height="88" rx="14" fill="url(#atlas-gradient)" />
+                <path d="M28 68L48 22l20 46h-9.6l-3.8-9H41.4l-3.8 9H28zm21-18.2h7.8L48 34.5l-6.8 15.3H49z" fill="#f6f8ff" />
+              </svg>
+            </div>
+            <figcaption>
+              <h3>Atlas Audio Library</h3>
+              <p>Electronic and hybrid orchestral collections with curated playlists across genres.</p>
+            </figcaption>
+          </figure>
+          <p>Atlas champions adventurous sound design that still feels grounded in melody. Their briefs lean into futuristic textures balanced with organic motifs, making them a natural fit for Samuel&apos;s hybrid compositions.</p>
+          <ul>
+            <li><strong>Collaboration highlights:</strong> Retrowave action cues, cinematic downtempo suites.</li>
+            <li><strong>Recent placements:</strong> Streaming series teasers, esports broadcast packages.</li>
+          </ul>
+        </div>
+        <div class="publisher-panel" id="publisher-panel-rosewood" data-option="rosewood" role="tabpanel" aria-labelledby="publisher-option-rosewood" hidden>
+          <figure class="publisher-hero">
+            <div class="publisher-logo" role="img" aria-label="Rosewood Scores placeholder logo">
+              <svg viewBox="0 0 96 96" aria-hidden="true" focusable="false">
+                <rect x="6" y="6" width="84" height="84" rx="18" fill="#6a2d44" />
+                <path d="M28 70c12-14 18-21 30-34l10 10-30 32h-10V70zm28-36c-2.4 0-4.4-2-4.4-4.4 0-2.4 2-4.4 4.4-4.4s4.4 2 4.4 4.4c0 2.4-2 4.4-4.4 4.4z" fill="#fbe7ef" />
+              </svg>
+            </div>
+            <figcaption>
+              <h3>Rosewood Scores</h3>
+              <p>Bespoke film and television placements with an ear for acoustic warmth.</p>
+            </figcaption>
+          </figure>
+          <p>Rosewood curates intimate ensembles and richly orchestrated themes, pairing Samuel&apos;s harmonic sensibility with directors seeking emotional nuance.</p>
+          <ul>
+            <li><strong>Collaboration highlights:</strong> Chamber string ballads, piano-led dramatic cues.</li>
+            <li><strong>Recent placements:</strong> Prestige docu-series, festival-bound short films.</li>
+          </ul>
+        </div>
+        <div class="publisher-panel" id="publisher-panel-pulse" data-option="pulse" role="tabpanel" aria-labelledby="publisher-option-pulse" hidden>
+          <figure class="publisher-hero">
+            <div class="publisher-logo" role="img" aria-label="Pulse Sync placeholder logo">
+              <svg viewBox="0 0 96 96" aria-hidden="true" focusable="false">
+                <rect x="8" y="8" width="80" height="80" rx="16" fill="#0c5a4a" />
+                <polyline points="20,58 34,46 42,54 54,34 62,42 76,30" fill="none" stroke="#9ef5d7" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </div>
+            <figcaption>
+              <h3>Pulse Sync</h3>
+              <p>Trailer-ready cues with flexible licensing options for fast-moving campaigns.</p>
+            </figcaption>
+          </figure>
+          <p>Pulse Sync thrives on high-impact statements and momentum. Samuel&apos;s layered builds and rhythmic hooks power their catalog&apos;s adrenaline-fueled playlists.</p>
+          <ul>
+            <li><strong>Collaboration highlights:</strong> Percussive hybrid anthems, tension risers.</li>
+            <li><strong>Recent placements:</strong> Game launch promos, blockbuster trailer spots.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <p class="publishers-outro">For clearance details or custom requests, reach out via the contact window.</p>
   </section>
 </template>
 

--- a/script.js
+++ b/script.js
@@ -140,13 +140,93 @@ function makeWindow({title, tpl, x=140, y=90, w=420}){
   return node;
 }
 
+function initTabbedWindow(windowEl, { optionSelector, panelSelector } = {}){
+  if(!windowEl || !optionSelector || !panelSelector) return;
+  const options = Array.from(windowEl.querySelectorAll(optionSelector));
+  if(!options.length) return;
+
+  const panels = new Map();
+  windowEl.querySelectorAll(panelSelector).forEach(panel => {
+    const key = panel.dataset.option;
+    if(!key) return;
+    panels.set(key, panel);
+    panel.hidden = !panel.classList.contains('is-active');
+  });
+
+  if(!panels.size) return;
+
+  const activate = (button) => {
+    if(!button) return;
+    const key = button.dataset.option;
+    if(!key || !panels.has(key)) return;
+
+    options.forEach(btn => {
+      const active = btn === button;
+      btn.classList.toggle('is-active', active);
+      btn.setAttribute('aria-selected', String(active));
+      btn.setAttribute('aria-expanded', String(active));
+    });
+
+    panels.forEach((panel, panelKey) => {
+      const active = panelKey === key;
+      panel.classList.toggle('is-active', active);
+      panel.hidden = !active;
+    });
+  };
+
+  const initial = options.find(btn => btn.classList.contains('is-active')) || options[0];
+  if(initial){
+    activate(initial);
+  }
+
+  options.forEach((btn, index) => {
+    btn.addEventListener('click', () => activate(btn));
+    btn.addEventListener('keydown', (event) => {
+      const { key } = event;
+      if(key === 'ArrowUp' || key === 'ArrowLeft'){
+        event.preventDefault();
+        const prev = options[(index - 1 + options.length) % options.length];
+        prev.focus();
+        activate(prev);
+      } else if(key === 'ArrowDown' || key === 'ArrowRight'){
+        event.preventDefault();
+        const next = options[(index + 1) % options.length];
+        next.focus();
+        activate(next);
+      }
+    });
+  });
+}
+
+function initAboutWindow(windowEl){
+  initTabbedWindow(windowEl, {
+    optionSelector: '.about-option',
+    panelSelector: '.about-panel'
+  });
+}
+
+function initPublishersWindow(windowEl){
+  initTabbedWindow(windowEl, {
+    optionSelector: '.publisher-option',
+    panelSelector: '.publisher-panel'
+  });
+}
+
 const openers = {
-  about: () => makeWindow({title:'About', tpl:'tpl-about', x:200, y:100}),
+  about: () => {
+    const win = makeWindow({title:'About', tpl:'tpl-about', x:200, y:100});
+    initAboutWindow(win);
+    return win;
+  },
   music: () => makeWindow({title:'Music', tpl:'tpl-music', x:260, y:120, w:520}),
   projects: () => makeWindow({title:'Projects', tpl:'tpl-projects', x:240, y:140, w:480}),
   contact: () => makeWindow({title:'Contact', tpl:'tpl-contact', x:220, y:160, w:360}),
   collaborators: () => makeWindow({title:'Collaborators', tpl:'tpl-collaborators', x:200, y:180, w:420}),
-  publishers: () => makeWindow({title:'Publishers', tpl:'tpl-publishers', x:220, y:200, w:420})
+  publishers: () => {
+    const win = makeWindow({title:'Publishers', tpl:'tpl-publishers', x:220, y:200, w:440});
+    initPublishersWindow(win);
+    return win;
+  }
 };
 
 // Sticky Notes

--- a/styles.css
+++ b/styles.css
@@ -94,3 +94,41 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 .sticky-btn{padding:6px 10px; border:2px solid #ccc; background:#eee; color:#000; border-radius:2px; cursor:pointer}
 .sticky-list{font-size:10px; color:#555}
 .sticky-list code{color:#000}
+
+/* About window */
+.content-section.about .about-blurb{margin-bottom:16px}
+.content-section.about .about-blurb ul{margin-bottom:0}
+.content-section.about .about-columns{display:flex; flex-direction:column; gap:16px}
+.content-section.about .about-panels{flex:1; min-width:0}
+.about-options{display:flex; flex-direction:column; gap:8px; align-self:flex-start}
+.about-option{padding:8px 12px; border:2px solid var(--dark); background:var(--win); text-align:left; cursor:pointer; font:inherit}
+.about-option.is-active{background:var(--accent); border-color:var(--accent-dim)}
+.about-option:focus-visible{outline:2px dashed var(--titlebar); outline-offset:2px}
+.about-panel{display:none}
+.about-panel.is-active{display:block}
+
+@media (min-width:640px){
+  .content-section.about .about-columns{flex-direction:row; align-items:flex-start}
+  .about-options{min-width:140px}
+}
+
+/* Publishers window */
+.content-section.publishers .publisher-columns{display:flex; flex-direction:column; gap:16px}
+.content-section.publishers .publisher-panels{flex:1; min-width:0}
+.publisher-options{display:flex; flex-direction:column; gap:8px; align-self:flex-start}
+.publisher-option{padding:8px 12px; border:2px solid var(--dark); background:var(--win); text-align:left; cursor:pointer; font:inherit}
+.publisher-option.is-active{background:var(--accent); border-color:var(--accent-dim)}
+.publisher-option:focus-visible{outline:2px dashed var(--titlebar); outline-offset:2px}
+.publisher-panel{display:none}
+.publisher-panel.is-active{display:block}
+.publisher-hero{display:flex; gap:16px; align-items:center; margin:0 0 16px}
+.publisher-hero figcaption{margin:0}
+.publisher-hero h3{margin:0 0 4px}
+.publisher-logo{width:96px; height:96px; border:2px solid var(--dark); border-radius:16px; background:var(--light); display:grid; place-items:center; flex:0 0 auto; overflow:hidden; box-shadow:inset -2px -2px 0 rgba(0,0,0,0.2)}
+.publisher-logo svg{width:100%; height:100%}
+.publishers-intro, .publishers-outro{max-width:62ch}
+
+@media (min-width:640px){
+  .content-section.publishers .publisher-columns{flex-direction:row; align-items:flex-start}
+  .publisher-options{min-width:200px}
+}


### PR DESCRIPTION
## Summary
- restore the original About blurb outside the tabbed panel layout so it remains visible by default
- refresh the Origins, Schooling, and Career panel copy with placeholder narratives
- add spacing styles for the new about blurb container while reusing existing responsive tab styling

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68da9384507883228e7cb2b782031443