### PR TITLE
Add tabbed placements layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,31 +286,108 @@
 
 <template id="tpl-projects">
   <section class="content-section projects" aria-labelledby="projects-heading">
-    <h2 id="projects-heading">Highlighted Projects</h2>
-    <article>
-      <h3>Neon Avenue</h3>
-      <p>A branching visual novel where the score reshapes itself around player decisions.</p>
-      <ul>
-        <li>Interactive soundtrack built with vertical remixing.</li>
-        <li>Foley design and implementation inside FMOD.</li>
-      </ul>
-    </article>
-    <article>
-      <h3>Midnight Dispatch</h3>
-      <p>An award-winning investigative podcast narrated by rotating journalists.</p>
-      <ul>
-        <li>Theme composition and episodic underscore.</li>
-        <li>Dialogue edit, mix, and final mastering.</li>
-      </ul>
-    </article>
-    <article>
-      <h3>Beacon Run</h3>
-      <p>Stylized action platformer featuring reactive music tied to combo multipliers.</p>
-      <ul>
-        <li>Designed adaptive audio system using Wwise.</li>
-        <li>Produced over 120 unique sound effects.</li>
-      </ul>
-    </article>
+    <h2 id="projects-heading">Broadcast Placements</h2>
+    <div class="placements-columns">
+      <div class="placements-options" role="tablist" aria-orientation="vertical">
+        <button class="placements-option is-active"
+                role="tab"
+                id="placements-option-aurora"
+                type="button"
+                data-option="aurora"
+                aria-controls="placements-panel-aurora"
+                aria-selected="true"
+                aria-expanded="true">Aurora FM</button>
+
+        <button class="placements-option"
+                role="tab"
+                id="placements-option-coastal"
+                type="button"
+                data-option="coastal"
+                aria-controls="placements-panel-coastal"
+                aria-selected="false"
+                aria-expanded="false">Coastal Wave Radio</button>
+
+        <button class="placements-option"
+                role="tab"
+                id="placements-option-metro"
+                type="button"
+                data-option="metro"
+                aria-controls="placements-panel-metro"
+                aria-selected="false"
+                aria-expanded="false">Metro Pulse Network</button>
+
+        <button class="placements-option"
+                role="tab"
+                id="placements-option-starboard"
+                type="button"
+                data-option="starboard"
+                aria-controls="placements-panel-starboard"
+                aria-selected="false"
+                aria-expanded="false">Starboard Broadcasting</button>
+      </div>
+
+      <div class="placements-panels">
+        <section class="placements-panel is-active"
+                 id="placements-panel-aurora"
+                 data-option="aurora"
+                 role="tabpanel"
+                 aria-labelledby="placements-option-aurora">
+          <h3>Morning Skyline Magazine</h3>
+          <figure class="placements-figure">
+            <div class="placements-image" role="img" aria-label="Placeholder collage for Aurora FM morning show"></div>
+            <figcaption>Live interviews blended with commuter-friendly grooves to launch the day in Aurora&apos;s skyline.</figcaption>
+          </figure>
+          <p>Segment scoring includes gentle synth pads and rhythmic guitar swells that ebb between guest commentary, city news,
+          and sponsor stingers.</p>
+          <p>Aurora FM uses the cues to create a calm yet energetic morning tone that keeps listeners tuned during drive time.</p>
+        </section>
+
+        <section class="placements-panel"
+                 id="placements-panel-coastal"
+                 data-option="coastal"
+                 role="tabpanel"
+                 aria-labelledby="placements-option-coastal"
+                 hidden>
+          <h3>Tidepool Sessions</h3>
+          <figure class="placements-figure">
+            <div class="placements-image" role="img" aria-label="Placeholder stage shot for Coastal Wave Radio"></div>
+            <figcaption>Acoustic performances recorded aboard the station&apos;s floating studio anchored just off the pier.</figcaption>
+          </figure>
+          <p>Warm folk instrumentation underscores each session, weaving in subtle wave foley for an intimate waterfront ambience.</p>
+          <p>Promotional spots highlight the weekly residency schedule and upcoming artist collaborations.</p>
+        </section>
+
+        <section class="placements-panel"
+                 id="placements-panel-metro"
+                 data-option="metro"
+                 role="tabpanel"
+                 aria-labelledby="placements-option-metro"
+                 hidden>
+          <h3>City Beat Dispatch</h3>
+          <figure class="placements-figure">
+            <div class="placements-image" role="img" aria-label="Placeholder aerial map graphic for Metro Pulse Network"></div>
+            <figcaption>Breaking headlines and on-the-ground reporting from Metro Pulse&apos;s rapid response newsroom.</figcaption>
+          </figure>
+          <p>Driving percussion cues and modular synth beds support the quick-hit storytelling segments and traffic advisories.</p>
+          <p>Long-form features lean into moody noir textures for investigative coverage across the urban core.</p>
+        </section>
+
+        <section class="placements-panel"
+                 id="placements-panel-starboard"
+                 data-option="starboard"
+                 role="tabpanel"
+                 aria-labelledby="placements-option-starboard"
+                 hidden>
+          <h3>Starlight Cinema Hour</h3>
+          <figure class="placements-figure">
+            <div class="placements-image" role="img" aria-label="Placeholder projector reel for Starboard Broadcasting"></div>
+            <figcaption>Classic film retrospectives paired with lush orchestral reimaginings commissioned for evening broadcasts.</figcaption>
+          </figure>
+          <p>Symphonic motifs and shimmering arpeggios guide listeners through director commentary, trivia, and sponsor spots.</p>
+          <p>A late-night bump set introduces each screening block with a soaring leitmotif tailored for primetime movie lovers.</p>
+        </section>
+      </div>
+    </div>
   </section>
 </template>
 

--- a/script.js
+++ b/script.js
@@ -204,6 +204,13 @@ function initPublishersWindow(windowEl){
   });
 }
 
+function initProjectsWindow(windowEl){
+  initTabbedWindow(windowEl, {
+    optionSelector: '.placements-option',
+    panelSelector: '.placements-panel'
+  });
+}
+
 /* ------- Openers ------- */
 const openers = {
   about: () => {
@@ -212,7 +219,11 @@ const openers = {
     return win;
   },
   music: () => makeWindow({title:'Music', tpl:'tpl-music', x:260, y:120, w:520}),
-  projects: () => makeWindow({title:'Projects', tpl:'tpl-projects', x:240, y:140, w:480}),
+  projects: () => {
+    const win = makeWindow({title:'Projects', tpl:'tpl-projects', x:240, y:140, w:520});
+    initProjectsWindow(win);
+    return win;
+  },
   contact: () => makeWindow({title:'Contact', tpl:'tpl-contact', x:220, y:160, w:360}),
   collaborators: () => makeWindow({title:'Collaborators', tpl:'tpl-collaborators', x:200, y:180, w:420}),
   publishers: () => {

--- a/styles.css
+++ b/styles.css
@@ -129,3 +129,20 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
   .content-section.publishers .publisher-columns{flex-direction:row; align-items:flex-start}
   .publisher-options{min-width:200px}
 }
+
+/* Placements window */
+.content-section.projects .placements-columns{display:flex; flex-direction:column; gap:16px}
+.content-section.projects .placements-panels{flex:1; min-width:0}
+.placements-options{display:flex; flex-direction:column; gap:8px; align-self:stretch; max-height:60vh; overflow-y:auto; padding-right:4px}
+.placements-option{padding:8px 12px; border:2px solid var(--dark); background:var(--win); text-align:left; cursor:pointer; font:inherit}
+.placements-option.is-active{background:var(--accent); border-color:var(--accent-dim)}
+.placements-option:focus-visible{outline:2px dashed var(--titlebar); outline-offset:2px}
+.placements-panel{display:none}
+.placements-panel.is-active{display:block}
+.placements-figure{margin:0 0 12px; display:grid; gap:8px}
+.placements-image{width:100%; aspect-ratio:3/2; border:2px dashed var(--dark); background:repeating-linear-gradient(135deg, rgba(0,0,0,.08) 0, rgba(0,0,0,.08) 16px, transparent 16px, transparent 32px); border-radius:8px}
+
+@media (min-width:720px){
+  .content-section.projects .placements-columns{flex-direction:row; align-items:flex-start}
+  .placements-options{min-width:220px}
+}


### PR DESCRIPTION
## Summary
- replace the Projects template with a tabbed placements layout featuring broadcast network buttons and matching panels
- add responsive styling for the placements columns, placeholder imagery blocks, and independent sidebar scrolling
- initialize the Projects window with the shared tabbed helper so active states mirror other windows

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab59f3f508322a3e03b1a06212c54