### PR TITLE
Add Placements tab initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -204,6 +204,13 @@ function initPublishersWindow(windowEl){
   });
 }
 
+function initPlacementsWindow(windowEl){
+  initTabbedWindow(windowEl, {
+    optionSelector: '.placements-option',
+    panelSelector: '.placements-panel'
+  });
+}
+
 /* ------- Openers ------- */
 const openers = {
   about: () => {
@@ -212,7 +219,11 @@ const openers = {
     return win;
   },
   music: () => makeWindow({title:'Music', tpl:'tpl-music', x:260, y:120, w:520}),
-  projects: () => makeWindow({title:'Projects', tpl:'tpl-projects', x:240, y:140, w:480}),
+  projects: () => {
+    const win = makeWindow({title:'Projects', tpl:'tpl-projects', x:240, y:140, w:480});
+    initPlacementsWindow(win);
+    return win;
+  },
   contact: () => makeWindow({title:'Contact', tpl:'tpl-contact', x:220, y:160, w:360}),
   collaborators: () => makeWindow({title:'Collaborators', tpl:'tpl-collaborators', x:200, y:180, w:420}),
   publishers: () => {


### PR DESCRIPTION
## Summary
- add a placements-specific tab initializer that reuses the shared tabbed-window helper
- invoke the placements initializer when opening the Projects window so its tab buttons manage their panels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab83c78088322a60a06cdc9a23287