### PR TITLE
Add portrait hero section to About window

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,13 @@
 <template id="tpl-about">
   <section class="content-section about" aria-labelledby="about-heading">
     <h2 id="about-heading">Instrumental Music for Media Composer</h2>
+    <div class="about-hero">
+      <img src="assets/img/Face.png" alt="Portrait of Samuel Witt">
+      <div class="about-blurb">
+        <p>Samuel Witt crafts vibrant, story-driven tracks for games, films, and experiential media. Each project begins with a collaborative deep dive to define tone, instrumentation, and the emotional story the music needs to support.</p>
+        <p>Currently working in his studio creating tracks for music libraries, independant artists, and production companies.</p>
+      </div>
+    </div>
     <div class="about-columns">
       <div class="about-options" role="tablist" aria-orientation="vertical">
         <!-- Active/default tab -->
@@ -142,8 +149,7 @@
              data-option="about"
              role="tabpanel"
              aria-labelledby="about-option-about">
-          <p>Samuel Witt crafts vibrant, story-driven tracks for games, films, and experiential media. Each project begins with a collaborative deep dive to define tone, instrumentation, and the emotional story the music needs to support.</p>
-          <p>Currently working in his studio creating tracks for music libraries, independant artists, and production companies.</p>
+          <p>Each engagement is built on close collaboration, ensuring the score elevates story and player experience from concept through delivery.</p>
           <ul>
             <li><strong>Expertise:</strong> Jazz/Funk, Electro Swing</li>
             <li><strong>Toolbox:</strong> Logic Pro, Native Instruments, M2 Macbook, Adam A7x Monitors, a suite of top tier Virtual Instruments</li>

--- a/styles.css
+++ b/styles.css
@@ -96,6 +96,9 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 .sticky-list code{color:#000}
 
 /* About window */
+.content-section.about .about-hero{display:flex; flex-direction:column; align-items:center; gap:16px; margin:0 0 16px}
+.content-section.about .about-hero img{width:160px; max-width:100%; height:auto; border:2px solid var(--dark); border-radius:12px; background:var(--light); box-shadow:inset -2px -2px 0 rgba(0,0,0,0.18)}
+.content-section.about .about-blurb{display:flex; flex-direction:column; gap:12px; max-width:65ch; text-align:left}
 .content-section.about .about-columns{display:flex; flex-direction:column; gap:16px}
 .content-section.about .about-panels{flex:1; min-width:0}
 .about-options{display:flex; flex-direction:column; gap:8px; align-self:flex-start}
@@ -106,6 +109,9 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 .about-panel.is-active{display:block}
 
 @media (min-width:640px){
+  .content-section.about .about-hero{flex-direction:row; align-items:flex-start; gap:24px}
+  .content-section.about .about-hero img{width:200px; flex:0 0 auto}
+  .content-section.about .about-blurb{align-items:flex-start}
   .content-section.about .about-columns{flex-direction:row; align-items:flex-start}
   .about-options{min-width:140px}
 }


### PR DESCRIPTION
## Summary
- introduce a portrait hero block with updated intro copy in the About window template
- add responsive styling for the new hero layout while preserving existing tab columns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dabe0b77d083228bf3401645acd34f