### PR TITLE
Add Atomic Age font styling for desktop icon labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Samuel Witt — Portfolio</title>
 <meta name="description" content="Interactive Win95-style desktop portfolio."/>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Atomic+Age&display=swap">
 <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -48,7 +48,8 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 }
 .icon .label {
   color:#fff;            /* 👈 white text (hard to see on yellow) */
-  font-size:12px;
+  font-family:"Atomic Age", cursive;
+  font-size:22px;
   text-shadow:1px 1px 0 #000;
   text-align:center;
 }


### PR DESCRIPTION
## Summary
- load the Atomic Age typeface from Google Fonts so it can be used globally
- apply the Atomic Age font to desktop icon labels and increase their size for better readability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dac397cb8883229165f69faec222ed