### PR TITLE
Add social links below about portrait

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,15 @@
   <section class="content-section about" aria-labelledby="about-heading">
     <h2 id="about-heading">Instrumental Music for Media Composer</h2>
     <div class="about-hero">
-      <img src="assets/img/Face.png" alt="Portrait of Samuel Witt">
+      <div class="about-portrait">
+        <img src="assets/img/Face.png" alt="Portrait of Samuel Witt">
+        <nav class="about-social" aria-label="Social media">
+          <ul>
+            <li><a href="https://www.instagram.com/" target="_blank" rel="noreferrer noopener">Instagram</a></li>
+            <li><a href="https://www.linkedin.com/" target="_blank" rel="noreferrer noopener">LinkedIn</a></li>
+          </ul>
+        </nav>
+      </div>
       <div class="about-blurb">
         <p>Samuel Witt crafts vibrant, story-driven tracks for games, films, and experiential media. Each project begins with a collaborative deep dive to define tone, instrumentation, and the emotional story the music needs to support.</p>
         <p>Currently working in his studio creating tracks for music libraries, independant artists, and production companies.</p>


### PR DESCRIPTION
## Summary
- wrap the about portrait image with a new container and add social navigation beneath it
- ensure the portrait and links remain before the existing about blurb content

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68dacff3710c83228a6d6717eb237628