### PR TITLE
Add start menu attribution blurb

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
 
 <!-- Start menu -->
 <div class="start-menu" id="startMenu" role="menu" aria-label="Start menu">
+  <p class="start-blurb">This Website was my by Samuel Witt in conjunction with AI models, ChatGPT5, Claude 3.1, Sora, and Patience.</p>
   <header>Samuel Witt</header>
   <div class="item" role="menuitem" data-open="about">
     <span>About</span>

--- a/styles.css
+++ b/styles.css
@@ -79,6 +79,7 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 
 /* Start menu */
 .start-menu{position:fixed; left:6px; bottom:36px; width:220px; background:#f0f0f0; border:2px solid var(--dark); border-top-color:var(--light); border-left-color:var(--light); box-shadow:4px 4px 0 var(--darker); display:none; z-index:9999}
+.start-menu .start-blurb{padding:10px 12px 8px; font-size:12px; line-height:1.4; margin:0; border-bottom:1px solid #ccc}
 .start-menu header{background:var(--titlebar); color:var(--titletext); padding:4px 6px; font-weight:700; border-bottom:1px solid #335}
 .start-menu .item{display:flex; align-items:center; gap:8px; padding:8px; cursor:pointer}
 .start-menu .item:hover{background:#dcdcdc}


### PR DESCRIPTION
## Summary
- add a blurb in the start menu acknowledging the collaborators
- style the new blurb so it integrates with the existing start menu layout

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db222b229c8322946aa8a9761aa35e