### PR TITLE
Expand placements carousel with show posters

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,103 +315,159 @@
     <div class="placements-carousel" role="region" aria-roledescription="carousel" aria-label="Broadcast placement posters" data-interval="3200">
       <div class="placements-track">
         <article class="placements-slide is-active"
-                 id="placements-slide-HBOMax"
-                 data-title="HBO Max — Game Changers"
+                 id="placements-slide-love-island"
+                 data-title="Peacock — Love Island USA"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="HBO Max — Game Changers"
+                 aria-label="Peacock — Love Island USA"
                  aria-hidden="false">
-          <h3>Game Changers</h3>
+          <h3>Love Island USA</h3>
           <figure class="placements-figure">
-            <div class="placements-image" role="img" aria-label="Placeholder collage for Aurora FM morning show"></div>
-            <figcaption>Live interviews blended with commuter-friendly grooves to launch the day in Aurora&apos;s skyline.</figcaption>
+            <img class="placements-image" src="assets/img/Love Island.png" alt="Love Island USA key art with couples framed against a neon heart." />
+            <figcaption>Sun-soaked pop cues and playful pulses help narrate recouplings and Casa Amor cliffhangers.</figcaption>
           </figure>
-          <p>Segment scoring includes gentle synth pads and rhythmic guitar swells that ebb between guest commentary, city news,
-          and sponsor stingers.</p>
-          <p>Aurora FM uses the cues to create a calm yet energetic morning tone that keeps listeners tuned during drive time.</p>
+          <p>Samuel delivers bright electronic textures that duck around rapid-fire narration while keeping pace with the islanders&apos; breakneck twists.</p>
         </article>
 
         <article class="placements-slide"
-                 id="placements-slide-coastal"
-                 data-title="Coastal Wave Radio — Tidepool Sessions"
+                 id="placements-slide-challenge"
+                 data-title="MTV — The Challenge"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="Coastal Wave Radio — Tidepool Sessions"
+                 aria-label="MTV — The Challenge"
                  aria-hidden="true">
-          <h3>Tidepool Sessions</h3>
+          <h3>The Challenge</h3>
           <figure class="placements-figure">
-            <div class="placements-image" role="img" aria-label="Placeholder stage shot for Coastal Wave Radio"></div>
-            <figcaption>Acoustic performances recorded aboard the station&apos;s floating studio anchored just off the pier.</figcaption>
+            <img class="placements-image" src="assets/img/challenge_xlg.jpg" alt="The Challenge key art with competitors poised for action." />
+            <figcaption>Hybrid trailer drums, distorted bass, and cinematic hits fuel elimination showdowns.</figcaption>
           </figure>
-          <p>Warm folk instrumentation underscores each session, weaving in subtle wave foley for an intimate waterfront ambience.</p>
-          <p>Promotional spots highlight the weekly residency schedule and upcoming artist collaborations.</p>
+          <p>Layered builds punch up daily mission teases and carry the tension through every tribunal reveal.</p>
         </article>
 
         <article class="placements-slide"
-                 id="placements-slide-metro"
-                 data-title="Metro Pulse Network — City Beat Dispatch"
+                 id="placements-slide-jersey-shore"
+                 data-title="MTV — Jersey Shore Family Vacation"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="Metro Pulse Network — City Beat Dispatch"
+                 aria-label="MTV — Jersey Shore Family Vacation"
                  aria-hidden="true">
-          <h3>City Beat Dispatch</h3>
+          <h3>Jersey Shore Family Vacation</h3>
           <figure class="placements-figure">
-            <div class="placements-image" role="img" aria-label="Placeholder aerial map graphic for Metro Pulse Network"></div>
-            <figcaption>Breaking headlines and on-the-ground reporting from Metro Pulse&apos;s rapid response newsroom.</figcaption>
+            <img class="placements-image" src="assets/img/jersey_shore_family_vacation_xlg.jpg" alt="Jersey Shore Family Vacation cast posing in matching track suits." />
+            <figcaption>Club-ready beats and cheeky risers underscore every prank war and family meeting.</figcaption>
           </figure>
-          <p>Driving percussion cues and modular synth beds support the quick-hit storytelling segments and traffic advisories.</p>
-          <p>Long-form features lean into moody noir textures for investigative coverage across the urban core.</p>
+          <p>Custom drops match Snooki and the gang&apos;s larger-than-life reactions while leaving space for quotable one-liners.</p>
         </article>
 
         <article class="placements-slide"
-                 id="placements-slide-starboard"
-                 data-title="Starboard Broadcasting — Starlight Cinema Hour"
+                 id="placements-slide-rupaul"
+                 data-title="MTV — RuPaul&apos;s Drag Race"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="Starboard Broadcasting — Starlight Cinema Hour"
+                 aria-label="MTV — RuPaul&apos;s Drag Race"
                  aria-hidden="true">
-          <h3>Starlight Cinema Hour</h3>
+          <h3>RuPaul&apos;s Drag Race</h3>
           <figure class="placements-figure">
-            <div class="placements-image" role="img" aria-label="Placeholder projector reel for Starboard Broadcasting"></div>
-            <figcaption>Classic film retrospectives paired with lush orchestral reimaginings commissioned for evening broadcasts.</figcaption>
+            <img class="placements-image" src="assets/img/rupauls_drag_race_xlg.jpg" alt="RuPaul in a sparkling gown flanked by Drag Race contestants." />
+            <figcaption>Runway strings, vogue-ready percussion, and glam synth swells elevate each sashé.</figcaption>
           </figure>
-          <p>Symphonic motifs and shimmering arpeggios guide listeners through director commentary, trivia, and sponsor spots.</p>
-          <p>A late-night bump set introduces each screening block with a soaring leitmotif tailored for primetime movie lovers.</p>
+          <p>The cues pivot from playful werkroom banter to high-drama lip-syncs without missing a beat.</p>
+        </article>
+
+        <article class="placements-slide"
+                 id="placements-slide-somebody-feed-phil"
+                 data-title="Netflix — Somebody Feed Phil"
+                 role="group"
+                 aria-roledescription="slide"
+                 aria-label="Netflix — Somebody Feed Phil"
+                 aria-hidden="true">
+          <h3>Somebody Feed Phil</h3>
+          <figure class="placements-figure">
+            <img class="placements-image" src="assets/img/Somebody Feed Phil.png" alt="Somebody Feed Phil poster featuring Phil Rosenthal holding chopsticks." />
+            <figcaption>Whimsical jazz motifs and brushed percussion mirror Phil&apos;s globe-trotting appetite.</figcaption>
+          </figure>
+          <p>Lighthearted cues bridge culinary discoveries with heartfelt interviews and travelogue montages.</p>
+        </article>
+
+        <article class="placements-slide"
+                 id="placements-slide-stranded"
+                 data-title="Netflix — Stranded with My Mother-in-Law"
+                 role="group"
+                 aria-roledescription="slide"
+                 aria-label="Netflix — Stranded with My Mother-in-Law"
+                 aria-hidden="true">
+          <h3>Stranded with My Mother-in-Law</h3>
+          <figure class="placements-figure">
+            <img class="placements-image" src="assets/img/Stranded with my Mother in Law.png" alt="Stranded with My Mother-in-Law poster showing couples on a tropical shore." />
+            <figcaption>Percussive marimba grooves and sly bass lines track shifting alliances on the beach.</figcaption>
+          </figure>
+          <p>Each cue balances reality-show mischief with warmth as families navigate the social experiment.</p>
+        </article>
+
+        <article class="placements-slide"
+                 id="placements-slide-below-deck"
+                 data-title="Bravo — Below Deck"
+                 role="group"
+                 aria-roledescription="slide"
+                 aria-label="Bravo — Below Deck"
+                 aria-hidden="true">
+          <h3>Below Deck</h3>
+          <figure class="placements-figure">
+            <img class="placements-image" src="assets/img/Below Deck.png" alt="Below Deck cast standing on the deck of a luxury yacht." />
+            <figcaption>Glossy house textures and nautical pulses follow the crew from galley to guest cabins.</figcaption>
+          </figure>
+          <p>Dynamic stems let producers dial in the right amount of tension for charter mishaps and romantic drama.</p>
+        </article>
+
+        <article class="placements-slide"
+                 id="placements-slide-atl-homicide"
+                 data-title="TV One — ATL Homicide"
+                 role="group"
+                 aria-roledescription="slide"
+                 aria-label="TV One — ATL Homicide"
+                 aria-hidden="true">
+          <h3>ATL Homicide</h3>
+          <figure class="placements-figure">
+            <img class="placements-image" src="assets/img/ATL Homicide.png" alt="ATL Homicide detectives posed in front of the Atlanta skyline." />
+            <figcaption>Brooding low brass and atmospheric pads underscore dramatic case reenactments.</figcaption>
+          </figure>
+          <p>The score leans into investigative grit, supporting veteran detectives as they revisit Atlanta&apos;s toughest files.</p>
+        </article>
+
+        <article class="placements-slide"
+                 id="placements-slide-sistas"
+                 data-title="BET — Tyler Perry&apos;s Sistas"
+                 role="group"
+                 aria-roledescription="slide"
+                 aria-label="BET — Tyler Perry&apos;s Sistas"
+                 aria-hidden="true">
+          <h3>Tyler Perry&apos;s Sistas</h3>
+          <figure class="placements-figure">
+            <img class="placements-image" src="assets/img/SISTAS_S8_VERT_KEYART_2x3_CLEAN_NO_TAG.jpg" alt="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast." />
+            <figcaption>Sultry R&amp;B progressions and soulful piano themes follow the friend group&apos;s highs and lows.</figcaption>
+          </figure>
+          <p>Motivic cues weave through dialogue, giving emotional glue to the ensemble&apos;s intertwined storylines.</p>
+        </article>
+
+        <article class="placements-slide"
+                 id="placements-slide-all-the-queens-men"
+                 data-title="BET+ — All The Queen&apos;s Men"
+                 role="group"
+                 aria-roledescription="slide"
+                 aria-label="BET+ — All The Queen&apos;s Men"
+                 aria-hidden="true">
+          <h3>All The Queen&apos;s Men</h3>
+          <figure class="placements-figure">
+            <img class="placements-image" src="assets/img/BET_ATQM_S4B_KEY_ART_PRIMARY_SOCIAL_16x9_CLEAN.jpg" alt="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting." />
+            <figcaption>Trap-infused strings and midnight synths amplify Madam&apos;s high-stakes empire.</figcaption>
+          </figure>
+          <p>Propulsive cues heighten club set-pieces while noir-tinged motifs drive the show&apos;s power plays home.</p>
         </article>
       </div>
 
       <div class="placements-controls">
         <button class="placements-control placements-prev" type="button" aria-label="Previous placement">‹</button>
-        <div class="placements-dots" role="tablist" aria-label="Select placement">
-          <button class="placements-dot is-active"
-                  type="button"
-                  role="tab"
-                  data-index="0"
-                  aria-controls="placements-slide-HBOMax"
-                  aria-selected="true"
-                  tabindex="0">HBO Max</button>
-          <button class="placements-dot"
-                  type="button"
-                  role="tab"
-                  data-index="1"
-                  aria-controls="placements-slide-coastal"
-                  aria-selected="false"
-                  tabindex="-1">Coastal Wave Radio</button>
-          <button class="placements-dot"
-                  type="button"
-                  role="tab"
-                  data-index="2"
-                  aria-controls="placements-slide-metro"
-                  aria-selected="false"
-                  tabindex="-1">Metro Pulse Network</button>
-          <button class="placements-dot"
-                  type="button"
-                  role="tab"
-                  data-index="3"
-                  aria-controls="placements-slide-starboard"
-                  aria-selected="false"
-                  tabindex="-1">Starboard Broadcasting</button>
-        </div>
+        <div class="placements-dots" role="tablist" aria-label="Select placement"></div>
         <button class="placements-control placements-next" type="button" aria-label="Next placement">›</button>
       </div>
       <p class="placements-status" aria-live="polite"></p>

--- a/script.js
+++ b/script.js
@@ -201,7 +201,36 @@ function initPlacementsCarousel(windowEl){
 
   const prevBtn = carousel.querySelector('.placements-prev');
   const nextBtn = carousel.querySelector('.placements-next');
-  const dots = Array.from(carousel.querySelectorAll('.placements-dot'));
+  const dotsContainer = carousel.querySelector('.placements-dots');
+  let dots = Array.from(carousel.querySelectorAll('.placements-dot'));
+
+  if(dotsContainer){
+    dotsContainer.innerHTML = '';
+    dots = slides.map((slide, index) => {
+      const dot = document.createElement('button');
+      dot.className = 'placements-dot';
+      dot.type = 'button';
+      dot.setAttribute('role', 'tab');
+      dot.dataset.index = String(index);
+
+      if(!slide.id){
+        slide.id = `placements-slide-${index + 1}`;
+      }
+      dot.setAttribute('aria-controls', slide.id);
+      dot.setAttribute('aria-selected', 'false');
+      dot.setAttribute('tabindex', '-1');
+
+      const heading = slide.querySelector('h3')?.textContent?.trim();
+      const label = heading || slide.dataset.title || `Slide ${index + 1}`;
+      dot.textContent = label;
+      dot.setAttribute('aria-label', label);
+
+      dotsContainer.appendChild(dot);
+      return dot;
+    });
+  }
+
+  dots = dots.filter(Boolean);
   const status = carousel.querySelector('.placements-status');
   const total = slides.length;
   let current = Math.max(0, slides.findIndex(slide => slide.classList.contains('is-active')));

--- a/styles.css
+++ b/styles.css
@@ -156,7 +156,8 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 .placements-slide:not(.is-active){pointer-events:none}
 .placements-slide h3{margin:0; font-size:20px}
 .placements-figure{margin:0; display:grid; gap:8px}
-.placements-image{width:100%; aspect-ratio:3/2; border:2px dashed var(--dark); background:repeating-linear-gradient(135deg, rgba(0,0,0,.08) 0, rgba(0,0,0,.08) 16px, transparent 16px, transparent 32px); border-radius:8px}
+.placements-image{width:100%; border-radius:8px; display:block; object-fit:cover}
+.placements-image:not(img){aspect-ratio:3/2; border:2px dashed var(--dark); background:repeating-linear-gradient(135deg, rgba(0,0,0,.08) 0, rgba(0,0,0,.08) 16px, transparent 16px, transparent 32px)}
 .placements-controls{display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap}
 .placements-control{width:36px; height:36px; border:2px solid var(--dark); border-radius:50%; background:var(--accent); font-size:20px; line-height:1; cursor:pointer; display:grid; place-items:center; transition:background 150ms ease, transform 150ms ease}
 .placements-control:disabled{opacity:.4; cursor:default}


### PR DESCRIPTION
## Summary
- replace the broadcast placements carousel with ten show-specific slides that use the official poster artwork and captions
- restyle placement images and populate the carousel dot controls dynamically so ARIA hooks stay aligned with each slide
- refresh the carousel status messaging to reflect the expanded slide list with real network titles

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68db35194b548322a109e5058e0cf8ba