### PR TITLE
Simplify placements carousel markup and sync accessible labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,14 +319,9 @@
                  data-title="Peacock — Love Island USA"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="Peacock — Love Island USA"
+                 aria-label="Love Island USA key art with couples framed against a neon heart."
                  aria-hidden="false">
-          <h3>Love Island USA</h3>
-          <figure class="placements-figure">
-            <img class="placements-image" src="assets/img/Love Island.png" alt="Love Island USA key art with couples framed against a neon heart." />
-            <figcaption>Sun-soaked pop cues and playful pulses help narrate recouplings and Casa Amor cliffhangers.</figcaption>
-          </figure>
-          <p>Samuel delivers bright electronic textures that duck around rapid-fire narration while keeping pace with the islanders&apos; breakneck twists.</p>
+          <img class="placements-image" src="assets/img/Love Island.png" alt="Love Island USA key art with couples framed against a neon heart." />
         </article>
 
         <article class="placements-slide"
@@ -334,14 +329,9 @@
                  data-title="MTV — The Challenge"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="MTV — The Challenge"
+                 aria-label="The Challenge key art with competitors poised for action."
                  aria-hidden="true">
-          <h3>The Challenge</h3>
-          <figure class="placements-figure">
-            <img class="placements-image" src="assets/img/challenge_xlg.jpg" alt="The Challenge key art with competitors poised for action." />
-            <figcaption>Hybrid trailer drums, distorted bass, and cinematic hits fuel elimination showdowns.</figcaption>
-          </figure>
-          <p>Layered builds punch up daily mission teases and carry the tension through every tribunal reveal.</p>
+          <img class="placements-image" src="assets/img/challenge_xlg.jpg" alt="The Challenge key art with competitors poised for action." />
         </article>
 
         <article class="placements-slide"
@@ -349,14 +339,9 @@
                  data-title="MTV — Jersey Shore Family Vacation"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="MTV — Jersey Shore Family Vacation"
+                 aria-label="Jersey Shore Family Vacation cast posing in matching track suits."
                  aria-hidden="true">
-          <h3>Jersey Shore Family Vacation</h3>
-          <figure class="placements-figure">
-            <img class="placements-image" src="assets/img/jersey_shore_family_vacation_xlg.jpg" alt="Jersey Shore Family Vacation cast posing in matching track suits." />
-            <figcaption>Club-ready beats and cheeky risers underscore every prank war and family meeting.</figcaption>
-          </figure>
-          <p>Custom drops match Snooki and the gang&apos;s larger-than-life reactions while leaving space for quotable one-liners.</p>
+          <img class="placements-image" src="assets/img/jersey_shore_family_vacation_xlg.jpg" alt="Jersey Shore Family Vacation cast posing in matching track suits." />
         </article>
 
         <article class="placements-slide"
@@ -364,14 +349,9 @@
                  data-title="MTV — RuPaul&apos;s Drag Race"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="MTV — RuPaul&apos;s Drag Race"
+                 aria-label="RuPaul in a sparkling gown flanked by Drag Race contestants."
                  aria-hidden="true">
-          <h3>RuPaul&apos;s Drag Race</h3>
-          <figure class="placements-figure">
-            <img class="placements-image" src="assets/img/rupauls_drag_race_xlg.jpg" alt="RuPaul in a sparkling gown flanked by Drag Race contestants." />
-            <figcaption>Runway strings, vogue-ready percussion, and glam synth swells elevate each sashé.</figcaption>
-          </figure>
-          <p>The cues pivot from playful werkroom banter to high-drama lip-syncs without missing a beat.</p>
+          <img class="placements-image" src="assets/img/rupauls_drag_race_xlg.jpg" alt="RuPaul in a sparkling gown flanked by Drag Race contestants." />
         </article>
 
         <article class="placements-slide"
@@ -379,14 +359,9 @@
                  data-title="Netflix — Somebody Feed Phil"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="Netflix — Somebody Feed Phil"
+                 aria-label="Somebody Feed Phil poster featuring Phil Rosenthal holding chopsticks."
                  aria-hidden="true">
-          <h3>Somebody Feed Phil</h3>
-          <figure class="placements-figure">
-            <img class="placements-image" src="assets/img/Somebody Feed Phil.png" alt="Somebody Feed Phil poster featuring Phil Rosenthal holding chopsticks." />
-            <figcaption>Whimsical jazz motifs and brushed percussion mirror Phil&apos;s globe-trotting appetite.</figcaption>
-          </figure>
-          <p>Lighthearted cues bridge culinary discoveries with heartfelt interviews and travelogue montages.</p>
+          <img class="placements-image" src="assets/img/Somebody Feed Phil.png" alt="Somebody Feed Phil poster featuring Phil Rosenthal holding chopsticks." />
         </article>
 
         <article class="placements-slide"
@@ -394,14 +369,9 @@
                  data-title="Netflix — Stranded with My Mother-in-Law"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="Netflix — Stranded with My Mother-in-Law"
+                 aria-label="Stranded with My Mother-in-Law poster showing couples on a tropical shore."
                  aria-hidden="true">
-          <h3>Stranded with My Mother-in-Law</h3>
-          <figure class="placements-figure">
-            <img class="placements-image" src="assets/img/Stranded with my Mother in Law.png" alt="Stranded with My Mother-in-Law poster showing couples on a tropical shore." />
-            <figcaption>Percussive marimba grooves and sly bass lines track shifting alliances on the beach.</figcaption>
-          </figure>
-          <p>Each cue balances reality-show mischief with warmth as families navigate the social experiment.</p>
+          <img class="placements-image" src="assets/img/Stranded with my Mother in Law.png" alt="Stranded with My Mother-in-Law poster showing couples on a tropical shore." />
         </article>
 
         <article class="placements-slide"
@@ -409,14 +379,9 @@
                  data-title="Bravo — Below Deck"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="Bravo — Below Deck"
+                 aria-label="Below Deck cast standing on the deck of a luxury yacht."
                  aria-hidden="true">
-          <h3>Below Deck</h3>
-          <figure class="placements-figure">
-            <img class="placements-image" src="assets/img/Below Deck.png" alt="Below Deck cast standing on the deck of a luxury yacht." />
-            <figcaption>Glossy house textures and nautical pulses follow the crew from galley to guest cabins.</figcaption>
-          </figure>
-          <p>Dynamic stems let producers dial in the right amount of tension for charter mishaps and romantic drama.</p>
+          <img class="placements-image" src="assets/img/Below Deck.png" alt="Below Deck cast standing on the deck of a luxury yacht." />
         </article>
 
         <article class="placements-slide"
@@ -424,14 +389,9 @@
                  data-title="TV One — ATL Homicide"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="TV One — ATL Homicide"
+                 aria-label="ATL Homicide detectives posed in front of the Atlanta skyline."
                  aria-hidden="true">
-          <h3>ATL Homicide</h3>
-          <figure class="placements-figure">
-            <img class="placements-image" src="assets/img/ATL Homicide.png" alt="ATL Homicide detectives posed in front of the Atlanta skyline." />
-            <figcaption>Brooding low brass and atmospheric pads underscore dramatic case reenactments.</figcaption>
-          </figure>
-          <p>The score leans into investigative grit, supporting veteran detectives as they revisit Atlanta&apos;s toughest files.</p>
+          <img class="placements-image" src="assets/img/ATL Homicide.png" alt="ATL Homicide detectives posed in front of the Atlanta skyline." />
         </article>
 
         <article class="placements-slide"
@@ -439,14 +399,9 @@
                  data-title="BET — Tyler Perry&apos;s Sistas"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="BET — Tyler Perry&apos;s Sistas"
+                 aria-label="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast."
                  aria-hidden="true">
-          <h3>Tyler Perry&apos;s Sistas</h3>
-          <figure class="placements-figure">
-            <img class="placements-image" src="assets/img/SISTAS_S8_VERT_KEYART_2x3_CLEAN_NO_TAG.jpg" alt="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast." />
-            <figcaption>Sultry R&amp;B progressions and soulful piano themes follow the friend group&apos;s highs and lows.</figcaption>
-          </figure>
-          <p>Motivic cues weave through dialogue, giving emotional glue to the ensemble&apos;s intertwined storylines.</p>
+          <img class="placements-image" src="assets/img/SISTAS_S8_VERT_KEYART_2x3_CLEAN_NO_TAG.jpg" alt="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast." />
         </article>
 
         <article class="placements-slide"
@@ -454,14 +409,9 @@
                  data-title="BET+ — All The Queen&apos;s Men"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="BET+ — All The Queen&apos;s Men"
+                 aria-label="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting."
                  aria-hidden="true">
-          <h3>All The Queen&apos;s Men</h3>
-          <figure class="placements-figure">
-            <img class="placements-image" src="assets/img/BET_ATQM_S4B_KEY_ART_PRIMARY_SOCIAL_16x9_CLEAN.jpg" alt="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting." />
-            <figcaption>Trap-infused strings and midnight synths amplify Madam&apos;s high-stakes empire.</figcaption>
-          </figure>
-          <p>Propulsive cues heighten club set-pieces while noir-tinged motifs drive the show&apos;s power plays home.</p>
+          <img class="placements-image" src="assets/img/BET_ATQM_S4B_KEY_ART_PRIMARY_SOCIAL_16x9_CLEAN.jpg" alt="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting." />
         </article>
       </div>
 

--- a/script.js
+++ b/script.js
@@ -199,6 +199,29 @@ function initPlacementsCarousel(windowEl){
   const slides = track ? Array.from(track.querySelectorAll('.placements-slide')) : [];
   if(!slides.length) return false;
 
+  const getSlideImage = (slide) => slide?.querySelector('.placements-image, img') || null;
+  const getSlideLabel = (slide, index) => {
+    const fallback = `Slide ${index + 1}`;
+    if(!slide) return fallback;
+
+    const image = getSlideImage(slide);
+    const alt = image?.getAttribute('alt')?.trim();
+    if(alt){
+      if(slide.getAttribute('aria-label') !== alt){
+        slide.setAttribute('aria-label', alt);
+      }
+      return alt;
+    }
+
+    const ariaLabel = slide.getAttribute('aria-label')?.trim();
+    if(ariaLabel) return ariaLabel;
+
+    const dataTitle = slide.dataset.title?.trim();
+    if(dataTitle) return dataTitle;
+
+    return fallback;
+  };
+
   const prevBtn = carousel.querySelector('.placements-prev');
   const nextBtn = carousel.querySelector('.placements-next');
   const dotsContainer = carousel.querySelector('.placements-dots');
@@ -220,8 +243,7 @@ function initPlacementsCarousel(windowEl){
       dot.setAttribute('aria-selected', 'false');
       dot.setAttribute('tabindex', '-1');
 
-      const heading = slide.querySelector('h3')?.textContent?.trim();
-      const label = heading || slide.dataset.title || `Slide ${index + 1}`;
+      const label = getSlideLabel(slide, index);
       dot.textContent = label;
       dot.setAttribute('aria-label', label);
 
@@ -242,10 +264,7 @@ function initPlacementsCarousel(windowEl){
 
   const updateStatus = () => {
     if(!status) return;
-    const title = slides[current]?.dataset.title
-      || slides[current]?.getAttribute('aria-label')
-      || slides[current]?.querySelector('h3')?.textContent?.trim()
-      || '';
+    const title = getSlideLabel(slides[current], current);
     const suffix = title ? ` — ${title}` : '';
     status.textContent = `Slide ${current + 1} of ${total}${suffix}`;
   };


### PR DESCRIPTION
## Summary
- update placements carousel slides to consist solely of poster images while keeping descriptive alt text for accessible labelling
- synchronize carousel controls by deriving dot labels and status text from each slide image alt, falling back to existing metadata when needed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db3be899e48322a1355ef6a0b2121f