### PR TITLE
Adjust placements carousel layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -150,13 +150,13 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 
 /* Placements window */
 .content-section.projects .placements-carousel{display:flex; flex-direction:column; gap:12px; max-width:720px; margin:0 auto}
-.placements-track{position:relative; min-height:320px; border:2px solid var(--dark); border-radius:14px; background:linear-gradient(135deg, #fefefe, #e3e3e3); overflow:hidden; box-shadow:inset -2px -2px 0 rgba(0,0,0,.18)}
-.placements-slide{position:absolute; inset:0; padding:18px 20px; display:grid; gap:12px; align-content:flex-start; opacity:0; transform:translateX(6%); transition:opacity 220ms ease, transform 220ms ease}
-.placements-slide.is-active{opacity:1; transform:translateX(0); pointer-events:auto; z-index:1}
+.placements-track{border:2px solid var(--dark); border-radius:14px; background:linear-gradient(135deg, #fefefe, #e3e3e3); box-shadow:inset -2px -2px 0 rgba(0,0,0,.18); display:grid}
+.placements-slide{padding:18px 20px; display:none; gap:12px; align-content:flex-start; grid-area:1/1}
+.placements-slide.is-active{display:grid; pointer-events:auto; animation:placements-slide-in 220ms ease both}
 .placements-slide:not(.is-active){pointer-events:none}
 .placements-slide h3{margin:0; font-size:20px}
 .placements-figure{margin:0; display:grid; gap:8px}
-.placements-image{width:100%; border-radius:8px; display:block; object-fit:cover}
+.placements-image{display:block; width:auto; height:auto; max-width:100%; border-radius:8px}
 .placements-image:not(img){aspect-ratio:3/2; border:2px dashed var(--dark); background:repeating-linear-gradient(135deg, rgba(0,0,0,.08) 0, rgba(0,0,0,.08) 16px, transparent 16px, transparent 32px)}
 .placements-controls{display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap}
 .placements-control{width:36px; height:36px; border:2px solid var(--dark); border-radius:50%; background:var(--accent); font-size:20px; line-height:1; cursor:pointer; display:grid; place-items:center; transition:background 150ms ease, transform 150ms ease}
@@ -170,6 +170,11 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 .placements-dot:focus-visible{outline:2px dashed var(--titlebar); outline-offset:2px}
 .placements-status{margin:0; font-size:12px; text-align:center; color:var(--darker)}
 
+@keyframes placements-slide-in{
+  from{opacity:0; transform:translateX(6%);}
+  to{opacity:1; transform:translateX(0);}
+}
+
 @media (min-width:640px){
   .placements-slide{grid-template-columns:minmax(220px, 1fr) minmax(0, 1.2fr)}
   .placements-slide h3{grid-column:1/-1; font-size:22px}
@@ -177,4 +182,5 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 
 @media (prefers-reduced-motion:reduce){
   .placements-slide{transition:none; transform:none}
+  .placements-slide.is-active{animation:none}
 }


### PR DESCRIPTION
## Summary
- let the placements carousel track expand naturally by removing fixed positioning and only rendering the active slide
- allow placement posters to use their intrinsic dimensions while still preventing horizontal overflow and add a reduced-motion fallback

## Testing
- Manual Playwright check of carousel keyboard navigation and auto-advance

------
https://chatgpt.com/codex/tasks/task_e_68db3c1fb3ac8322b8b453016d627312