### PR TITLE
Add placement audio blurbs and responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,7 +321,23 @@
                  aria-roledescription="slide"
                  aria-label="Love Island USA key art with couples framed against a neon heart."
                  aria-hidden="false">
-          <img class="placements-image" src="assets/img/Love Island.png" alt="Love Island USA key art with couples framed against a neon heart." />
+          <h3 class="placements-title">Peacock — Love Island USA</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image" src="assets/img/Love Island.png" alt="Love Island USA key art with couples framed against a neon heart." />
+            </figure>
+            <div class="placements-copy">
+              <p class="placements-blurb">A bright teaser about the Love Island USA sync will live here, highlighting the sun-soaked romance the cue supports.</p>
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">Love Island USA — “Hands to the Ceiling” promo cue</span>
+                  <audio controls preload="metadata" src="assets/audio/handstotheceiling.mp3">
+                    Download the track “Hands to the Ceiling” featured in Love Island USA.
+                  </audio>
+                </li>
+              </ul>
+            </div>
+          </div>
         </article>
 
         <article class="placements-slide"
@@ -331,7 +347,23 @@
                  aria-roledescription="slide"
                  aria-label="The Challenge key art with competitors poised for action."
                  aria-hidden="true">
-          <img class="placements-image" src="assets/img/challenge_xlg.jpg" alt="The Challenge key art with competitors poised for action." />
+          <h3 class="placements-title">MTV — The Challenge</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image" src="assets/img/challenge_xlg.jpg" alt="The Challenge key art with competitors poised for action." />
+            </figure>
+            <div class="placements-copy">
+              <p class="placements-blurb">A one-line spotlight about this Challenge placement will go here to capture the grit and high stakes of the episode.</p>
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">The Challenge — “Get First Place” elimination recap cue</span>
+                  <audio controls preload="metadata" src="assets/audio/getfirstplace.mp3">
+                    Download the track “Get First Place” featured in MTV's The Challenge.
+                  </audio>
+                </li>
+              </ul>
+            </div>
+          </div>
         </article>
 
         <article class="placements-slide"
@@ -341,7 +373,23 @@
                  aria-roledescription="slide"
                  aria-label="Jersey Shore Family Vacation cast posing in matching track suits."
                  aria-hidden="true">
-          <img class="placements-image" src="assets/img/jersey_shore_family_vacation_xlg.jpg" alt="Jersey Shore Family Vacation cast posing in matching track suits." />
+          <h3 class="placements-title">MTV — Jersey Shore Family Vacation</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image" src="assets/img/jersey_shore_family_vacation_xlg.jpg" alt="Jersey Shore Family Vacation cast posing in matching track suits." />
+            </figure>
+            <div class="placements-copy">
+              <p class="placements-blurb">A quick note about the Jersey Shore Family Vacation episode will summarize how the cue amps the boardwalk drama.</p>
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">Jersey Shore Family Vacation — “Little Bird” house party cue</span>
+                  <audio controls preload="metadata" src="assets/audio/littlebird.mp3">
+                    Download the track “Little Bird” featured in Jersey Shore Family Vacation.
+                  </audio>
+                </li>
+              </ul>
+            </div>
+          </div>
         </article>
 
         <article class="placements-slide"
@@ -351,7 +399,23 @@
                  aria-roledescription="slide"
                  aria-label="RuPaul in a sparkling gown flanked by Drag Race contestants."
                  aria-hidden="true">
-          <img class="placements-image" src="assets/img/rupauls_drag_race_xlg.jpg" alt="RuPaul in a sparkling gown flanked by Drag Race contestants." />
+          <h3 class="placements-title">MTV — RuPaul&apos;s Drag Race</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image" src="assets/img/rupauls_drag_race_xlg.jpg" alt="RuPaul in a sparkling gown flanked by Drag Race contestants." />
+            </figure>
+            <div class="placements-copy">
+              <p class="placements-blurb">A glamorous sentence about the Drag Race placement will live here, nodding to the runway moment the cue underscores.</p>
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">RuPaul&apos;s Drag Race — “Urbana Prolific” runway reveal cue</span>
+                  <audio controls preload="metadata" src="assets/audio/urbanaprolific.mp3">
+                    Download the track “Urbana Prolific” featured in RuPaul&apos;s Drag Race.
+                  </audio>
+                </li>
+              </ul>
+            </div>
+          </div>
         </article>
 
         <article class="placements-slide"
@@ -361,7 +425,23 @@
                  aria-roledescription="slide"
                  aria-label="Somebody Feed Phil poster featuring Phil Rosenthal holding chopsticks."
                  aria-hidden="true">
-          <img class="placements-image" src="assets/img/Somebody Feed Phil.png" alt="Somebody Feed Phil poster featuring Phil Rosenthal holding chopsticks." />
+          <h3 class="placements-title">Netflix — Somebody Feed Phil</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image" src="assets/img/Somebody Feed Phil.png" alt="Somebody Feed Phil poster featuring Phil Rosenthal holding chopsticks." />
+            </figure>
+            <div class="placements-copy">
+              <p class="placements-blurb">A single-sentence note about the Somebody Feed Phil segment will go here to hint at the travelogue flavor.</p>
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">Somebody Feed Phil — “Drawing Conclusions” city montage cue</span>
+                  <audio controls preload="metadata" src="assets/audio/drawingconclusions.mp3">
+                    Download the track “Drawing Conclusions” featured in Somebody Feed Phil.
+                  </audio>
+                </li>
+              </ul>
+            </div>
+          </div>
         </article>
 
         <article class="placements-slide"
@@ -371,7 +451,23 @@
                  aria-roledescription="slide"
                  aria-label="Stranded with My Mother-in-Law poster showing couples on a tropical shore."
                  aria-hidden="true">
-          <img class="placements-image" src="assets/img/Stranded with my Mother in Law.png" alt="Stranded with My Mother-in-Law poster showing couples on a tropical shore." />
+          <h3 class="placements-title">Netflix — Stranded with My Mother-in-Law</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image" src="assets/img/Stranded with my Mother in Law.png" alt="Stranded with My Mother-in-Law poster showing couples on a tropical shore." />
+            </figure>
+            <div class="placements-copy">
+              <p class="placements-blurb">A placeholder sentence about this Stranded with My Mother-in-Law feature will describe the tropical tension the cue scores.</p>
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">Stranded with My Mother-in-Law — “All In Together Now” challenge setup cue</span>
+                  <audio controls preload="metadata" src="assets/audio/allintogethernow.mp3">
+                    Download the track “All In Together Now” featured in Stranded with My Mother-in-Law.
+                  </audio>
+                </li>
+              </ul>
+            </div>
+          </div>
         </article>
 
         <article class="placements-slide"
@@ -381,7 +477,23 @@
                  aria-roledescription="slide"
                  aria-label="Below Deck cast standing on the deck of a luxury yacht."
                  aria-hidden="true">
-          <img class="placements-image" src="assets/img/Below Deck.png" alt="Below Deck cast standing on the deck of a luxury yacht." />
+          <h3 class="placements-title">Bravo — Below Deck</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image" src="assets/img/Below Deck.png" alt="Below Deck cast standing on the deck of a luxury yacht." />
+            </figure>
+            <div class="placements-copy">
+              <p class="placements-blurb">A concise blurb about this Below Deck appearance will outline how the cue fuels the charter&apos;s on-deck drama.</p>
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">Below Deck — “Sleek Chico” luxury handoff cue</span>
+                  <audio controls preload="metadata" src="assets/audio/sleekchico.mp3">
+                    Download the track “Sleek Chico” featured in Bravo&apos;s Below Deck.
+                  </audio>
+                </li>
+              </ul>
+            </div>
+          </div>
         </article>
 
         <article class="placements-slide"
@@ -391,7 +503,23 @@
                  aria-roledescription="slide"
                  aria-label="ATL Homicide detectives posed in front of the Atlanta skyline."
                  aria-hidden="true">
-          <img class="placements-image" src="assets/img/ATL Homicide.png" alt="ATL Homicide detectives posed in front of the Atlanta skyline." />
+          <h3 class="placements-title">TV One — ATL Homicide</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image" src="assets/img/ATL Homicide.png" alt="ATL Homicide detectives posed in front of the Atlanta skyline." />
+            </figure>
+            <div class="placements-copy">
+              <p class="placements-blurb">A single line about ATL Homicide will describe how the cue heightens the investigative stakes.</p>
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">ATL Homicide — “Big Ocean” case file montage cue</span>
+                  <audio controls preload="metadata" src="assets/audio/bigocean.mp3">
+                    Download the track “Big Ocean” featured in ATL Homicide.
+                  </audio>
+                </li>
+              </ul>
+            </div>
+          </div>
         </article>
 
         <article class="placements-slide"
@@ -401,7 +529,23 @@
                  aria-roledescription="slide"
                  aria-label="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast."
                  aria-hidden="true">
-          <img class="placements-image" src="assets/img/SISTAS_S8_VERT_KEYART_2x3_CLEAN_NO_TAG.jpg" alt="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast." />
+          <h3 class="placements-title">BET — Tyler Perry&apos;s Sistas</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image" src="assets/img/SISTAS_S8_VERT_KEYART_2x3_CLEAN_NO_TAG.jpg" alt="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast." />
+            </figure>
+            <div class="placements-copy">
+              <p class="placements-blurb">A quick description for Tyler Perry&apos;s Sistas will note how the cue supports the season&apos;s relationship twists.</p>
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">Tyler Perry&apos;s Sistas — “Carried Away” cliffhanger cue</span>
+                  <audio controls preload="metadata" src="assets/audio/carriedaway.mp3">
+                    Download the track “Carried Away” featured in Tyler Perry&apos;s Sistas.
+                  </audio>
+                </li>
+              </ul>
+            </div>
+          </div>
         </article>
 
         <article class="placements-slide"
@@ -411,7 +555,29 @@
                  aria-roledescription="slide"
                  aria-label="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting."
                  aria-hidden="true">
-          <img class="placements-image" src="assets/img/BET_ATQM_S4B_KEY_ART_PRIMARY_SOCIAL_16x9_CLEAN.jpg" alt="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting." />
+          <h3 class="placements-title">BET+ — All The Queen&apos;s Men</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image" src="assets/img/BET_ATQM_S4B_KEY_ART_PRIMARY_SOCIAL_16x9_CLEAN.jpg" alt="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting." />
+            </figure>
+            <div class="placements-copy">
+              <p class="placements-blurb">A single sentence about All The Queen&apos;s Men will outline how these cues accent the show&apos;s high-stakes cabaret world.</p>
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">All The Queen&apos;s Men — “Get First Place” title fight cue</span>
+                  <audio controls preload="metadata" src="assets/audio/getfirstplace.mp3">
+                    Download the track “Get First Place” featured in All The Queen&apos;s Men.
+                  </audio>
+                </li>
+                <li>
+                  <span class="placements-track-description">All The Queen&apos;s Men — “Carried Away” lounge reveal cue</span>
+                  <audio controls preload="metadata" src="assets/audio/carriedaway.mp3">
+                    Download the track “Carried Away” featured in All The Queen&apos;s Men.
+                  </audio>
+                </li>
+              </ul>
+            </div>
+          </div>
         </article>
       </div>
 

--- a/styles.css
+++ b/styles.css
@@ -151,12 +151,19 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 /* Placements window */
 .content-section.projects .placements-carousel{display:flex; flex-direction:column; gap:12px; max-width:720px; margin:0 auto}
 .placements-track{border:2px solid var(--dark); border-radius:14px; background:linear-gradient(135deg, #fefefe, #e3e3e3); box-shadow:inset -2px -2px 0 rgba(0,0,0,.18); display:grid}
-.placements-slide{padding:18px 20px; display:none; gap:12px; align-content:flex-start; grid-area:1/1}
-.placements-slide.is-active{display:grid; pointer-events:auto; animation:placements-slide-in 220ms ease both}
+.placements-slide{padding:18px 20px; display:none; flex-direction:column; gap:16px; grid-area:1/1}
+.placements-slide.is-active{display:flex; pointer-events:auto; animation:placements-slide-in 220ms ease both}
 .placements-slide:not(.is-active){pointer-events:none}
 .placements-slide h3{margin:0; font-size:20px}
-.placements-figure{margin:0; display:grid; gap:8px}
-.placements-image{display:block; width:auto; height:auto; max-width:100%; border-radius:8px}
+.placements-details{display:flex; flex-direction:column; gap:18px}
+.placements-copy{display:flex; flex-direction:column; gap:18px}
+.placements-blurb{margin:0}
+.placements-tracks{margin:0; padding:0; list-style:none; display:flex; flex-direction:column; gap:18px}
+.placements-tracks li{display:flex; flex-direction:column; gap:8px}
+.placements-track-description{font-weight:600}
+.placements-tracks audio{width:100%; max-width:100%}
+.placements-figure{margin:0; display:flex; flex-direction:column; gap:8px}
+.placements-image{display:block; width:100%; height:auto; border-radius:8px}
 .placements-image:not(img){aspect-ratio:3/2; border:2px dashed var(--dark); background:repeating-linear-gradient(135deg, rgba(0,0,0,.08) 0, rgba(0,0,0,.08) 16px, transparent 16px, transparent 32px)}
 .placements-controls{display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap}
 .placements-control{width:36px; height:36px; border:2px solid var(--dark); border-radius:50%; background:var(--accent); font-size:20px; line-height:1; cursor:pointer; display:grid; place-items:center; transition:background 150ms ease, transform 150ms ease}
@@ -176,8 +183,11 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 }
 
 @media (min-width:640px){
-  .placements-slide{grid-template-columns:minmax(220px, 1fr) minmax(0, 1.2fr)}
-  .placements-slide h3{grid-column:1/-1; font-size:22px}
+  .placements-slide{gap:22px}
+  .placements-slide h3{font-size:22px}
+  .placements-details{flex-direction:row; align-items:flex-start; gap:24px}
+  .placements-figure{flex:0 0 260px; max-width:320px}
+  .placements-copy{flex:1}
 }
 
 @media (prefers-reduced-motion:reduce){


### PR DESCRIPTION
## Summary
- expand each broadcast placement slide to include key art figures, placeholder blurbs, and cue lists with audio players
- add descriptive copy and download fallbacks for every cue, including support for dual-track placements
- update carousel styling for the new layout so artwork, blurbs, and audio controls align cleanly on mobile and desktop

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dda87f9cb883229253c1e4f800cbe3