### PR TITLE
Combine Peacock and BET placements into a single carousel slide

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,13 +315,29 @@
     <div class="placements-carousel" role="region" aria-roledescription="carousel" aria-label="Broadcast placement posters" data-interval="3200">
       <div class="placements-track">
         <article class="placements-slide is-active"
-                 id="placements-slide-love-island"
-                 data-title="Peacock — Love Island USA"
+                 id="placements-slide-peacock-bet"
+                 data-title="Peacock &amp; BET — Love Island USA, Sistas, All The Queen&apos;s Men"
                  role="group"
                  aria-roledescription="slide"
-                 aria-label="Love Island USA key art with couples framed against a neon heart."
+                 aria-label="Peacock and BET placements for Love Island USA, Tyler Perry&apos;s Sistas, and All The Queen&apos;s Men."
                  aria-hidden="false">
-          <img class="placements-image" src="assets/img/Love Island.png" alt="Love Island USA key art with couples framed against a neon heart." />
+          <figure class="placements-figure">
+            <img class="placements-image"
+                 src="assets/img/Love Island.png"
+                 alt="Love Island USA key art representing placements for Love Island USA, Tyler Perry&apos;s Sistas, and All The Queen&apos;s Men."
+            />
+            <figcaption>Peacock &amp; BET flagship reality and drama showcases</figcaption>
+          </figure>
+          <h3>Love Island USA, Tyler Perry&apos;s Sistas &amp; All The Queen&apos;s Men</h3>
+          <p>Samuel&apos;s pulsing pop-soul cues lift Peacock&apos;s Love Island USA alongside BET&apos;s signature dramas Tyler Perry&apos;s Sistas and All The Queen&apos;s Men.</p>
+          <div class="placements-tracklist" aria-label="Featured cue for the Peacock and BET placements">
+            <h4>Featured cue</h4>
+            <p><strong>Hands to the Ceiling</strong></p>
+            <audio controls preload="metadata" src="assets/audio/handstotheceiling.mp3">
+              Your browser does not support the audio element. Download the track
+              <a href="assets/audio/handstotheceiling.mp3">here</a>.
+            </audio>
+          </div>
         </article>
 
         <article class="placements-slide"
@@ -394,25 +410,6 @@
           <img class="placements-image" src="assets/img/ATL Homicide.png" alt="ATL Homicide detectives posed in front of the Atlanta skyline." />
         </article>
 
-        <article class="placements-slide"
-                 id="placements-slide-sistas"
-                 data-title="BET — Tyler Perry&apos;s Sistas"
-                 role="group"
-                 aria-roledescription="slide"
-                 aria-label="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast."
-                 aria-hidden="true">
-          <img class="placements-image" src="assets/img/SISTAS_S8_VERT_KEYART_2x3_CLEAN_NO_TAG.jpg" alt="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast." />
-        </article>
-
-        <article class="placements-slide"
-                 id="placements-slide-all-the-queens-men"
-                 data-title="BET+ — All The Queen&apos;s Men"
-                 role="group"
-                 aria-roledescription="slide"
-                 aria-label="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting."
-                 aria-hidden="true">
-          <img class="placements-image" src="assets/img/BET_ATQM_S4B_KEY_ART_PRIMARY_SOCIAL_16x9_CLEAN.jpg" alt="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting." />
-        </article>
       </div>
 
       <div class="placements-controls">

--- a/styles.css
+++ b/styles.css
@@ -158,6 +158,9 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 .placements-figure{margin:0; display:grid; gap:8px}
 .placements-image{display:block; width:auto; height:auto; max-width:100%; border-radius:8px}
 .placements-image:not(img){aspect-ratio:3/2; border:2px dashed var(--dark); background:repeating-linear-gradient(135deg, rgba(0,0,0,.08) 0, rgba(0,0,0,.08) 16px, transparent 16px, transparent 32px)}
+.placements-tracklist{display:grid; gap:8px; padding:12px; border:1px solid var(--dark); border-radius:10px; background:rgba(255,255,255,.72)}
+.placements-tracklist h4{margin:0; font-size:16px}
+.placements-tracklist p{margin:0}
 .placements-controls{display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap}
 .placements-control{width:36px; height:36px; border:2px solid var(--dark); border-radius:50%; background:var(--accent); font-size:20px; line-height:1; cursor:pointer; display:grid; place-items:center; transition:background 150ms ease, transform 150ms ease}
 .placements-control:disabled{opacity:.4; cursor:default}


### PR DESCRIPTION
## Summary
- group the Love Island USA, Tyler Perry's Sistas, and All The Queen's Men placements into one Peacock & BET carousel slide with updated metadata
- embed the "Hands to the Ceiling" audio player within the shared placements track list for the grouped shows
- style the new placements track list container to keep the layout cohesive

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dda880e6d483228dfa4dc081a878a1