### PR TITLE
Fix Peacock BET slide structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,44 +321,56 @@
                  aria-roledescription="slide"
                  aria-label="Peacock and BET placements for Love Island USA, Tyler Perry&apos;s Sistas, and All The Queen&apos;s Men."
                  aria-hidden="false">
-<article class="placements-slide is-active"
-         id="placements-slide-peacock-bet"
-         data-title="Peacock &amp; BET — Love Island USA, Sistas, All The Queen&apos;s Men"
-         role="group"
-         aria-roledescription="slide"
-         aria-label="Peacock and BET placements for Love Island USA, Tyler Perry&apos;s Sistas, and All The Queen&apos;s Men."
-         aria-hidden="false">
+          <h3 class="placements-title">Peacock — Love Island USA</h3>
+          <div class="placements-details">
+            <figure class="placements-figure">
+              <img class="placements-image"
+                   src="assets/img/Love Island.png"
+                   alt="Love Island USA key art representing placements for Love Island USA, Tyler Perry’s Sistas, and All The Queen’s Men." />
+              <!-- figcaption intentionally removed to avoid visible captions -->
+            </figure>
 
-  <h3 class="placements-title">Peacock — Love Island USA</h3>
+            <div class="placements-copy">
+              <p class="placements-blurb">
+                Samuel’s pulsing pop-soul cues lift Peacock’s <em>Love Island USA</em> alongside BET’s signature dramas
+                <em>Tyler Perry’s Sistas</em> and <em>All The Queen’s Men</em>.
+              </p>
 
-  <div class="placements-details">
-    <figure class="placements-figure">
-      <img class="placements-image"
-           src="assets/img/Love Island.png"
-           alt="Love Island USA key art representing placements for Love Island USA, Tyler Perry’s Sistas, and All The Queen’s Men." />
-      <!-- figcaption intentionally removed to avoid visible captions -->
-    </figure>
-
-    <div class="placements-copy">
-      <p class="placements-blurb">
-        Samuel’s pulsing pop-soul cues lift Peacock’s <em>Love Island USA</em> alongside BET’s signature dramas
-        <em>Tyler Perry’s Sistas</em> and <em>All The Queen’s Men</em>.
-      </p>
-
-      <ul class="placements-tracks">
-        <li>
-          <span class="placements-track-description">
-            Love Island USA — “Hands to the Ceiling” promo cue
-          </span>
-          <audio controls preload="metadata" src="assets/audio/handstotheceiling.mp3">
-            Download the track “Hands to the Ceiling” featured in Love Island USA.
-          </audio>
-        </li>
-      </ul>
-    </div>
-  </div>
-</article>
-
+              <ul class="placements-tracks">
+                <li>
+                  <span class="placements-track-description">
+                    Love Island USA — “Hands to the Ceiling” promo cue
+                  </span>
+                  <audio controls preload="metadata" src="assets/audio/handstotheceiling.mp3">
+                    Download the track “Hands to the Ceiling” featured in Love Island USA.
+                  </audio>
+                </li>
+                <li>
+                  <span class="placements-track-description">
+                    Tyler Perry&apos;s Sistas — “Carried Away” cliffhanger cue
+                  </span>
+                  <audio controls preload="metadata" src="assets/audio/carriedaway.mp3">
+                    Download the track “Carried Away” featured in Tyler Perry&apos;s Sistas.
+                  </audio>
+                </li>
+                <li>
+                  <span class="placements-track-description">
+                    All The Queen&apos;s Men — “Get First Place” title fight cue
+                  </span>
+                  <audio controls preload="metadata" src="assets/audio/getfirstplace.mp3">
+                    Download the track “Get First Place” featured in All The Queen&apos;s Men.
+                  </audio>
+                </li>
+                <li>
+                  <span class="placements-track-description">
+                    All The Queen&apos;s Men — “Carried Away” lounge reveal cue
+                  </span>
+                  <audio controls preload="metadata" src="assets/audio/carriedaway.mp3">
+                    Download the track “Carried Away” featured in All The Queen&apos;s Men.
+                  </audio>
+                </li>
+              </ul>
+            </div>
           </div>
         </article>
 
@@ -543,78 +555,6 @@
             </div>
           </div>
         </article>
-
-<article class="placements-slide"
-         id="placements-slide-sistas"
-         data-title="BET — Tyler Perry&apos;s Sistas"
-         role="group"
-         aria-roledescription="slide"
-         aria-label="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast."
-         aria-hidden="true">
-  <h3 class="placements-title">BET — Tyler Perry&apos;s Sistas</h3>
-  <div class="placements-details">
-    <figure class="placements-figure">
-      <img class="placements-image"
-           src="assets/img/SISTAS_S8_VERT_KEYART_2x3_CLEAN_NO_TAG.jpg"
-           alt="Tyler Perry&apos;s Sistas season key art featuring the ensemble cast." />
-    </figure>
-    <div class="placements-copy">
-      <p class="placements-blurb">
-        A quick description for Tyler Perry&apos;s Sistas will note how the cue supports the season&apos;s relationship twists.
-      </p>
-      <ul class="placements-tracks">
-        <li>
-          <span class="placements-track-description">
-            Tyler Perry&apos;s Sistas — “Carried Away” cliffhanger cue
-          </span>
-          <audio controls preload="metadata" src="assets/audio/carriedaway.mp3">
-            Download the track “Carried Away” featured in Tyler Perry&apos;s Sistas.
-          </audio>
-        </li>
-      </ul>
-    </div>
-  </div>
-</article>
-
-<article class="placements-slide"
-         id="placements-slide-all-the-queens-men"
-         data-title="BET+ — All The Queen&apos;s Men"
-         role="group"
-         aria-roledescription="slide"
-         aria-label="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting."
-         aria-hidden="true">
-  <h3 class="placements-title">BET+ — All The Queen&apos;s Men</h3>
-  <div class="placements-details">
-    <figure class="placements-figure">
-      <img class="placements-image"
-           src="assets/img/BET_ATQM_S4B_KEY_ART_PRIMARY_SOCIAL_16x9_CLEAN.jpg"
-           alt="All The Queen&apos;s Men key art with Madam and her dancers in dramatic lighting." />
-    </figure>
-    <div class="placements-copy">
-      <p class="placements-blurb">
-        A single sentence about All The Queen&apos;s Men will outline how these cues accent the show&apos;s high-stakes cabaret world.
-      </p>
-      <ul class="placements-tracks">
-        <li>
-          <span class="placements-track-description">
-            All The Queen&apos;s Men — “Get First Place” title fight cue
-          </span>
-          <audio controls preload="metadata" src="assets/audio/getfirstplace.mp3">
-            Download the track “Get First Place” featured in All The Queen&apos;s Men.
-          </audio>
-        </li>
-        <li>
-          <span class="placements-track-description">
-            All The Queen&apos;s Men — “Carried Away” lounge reveal cue
-          </span>
-          <audio controls preload="metadata" src="assets/audio/carriedaway.mp3">
-            Download the track “Carried Away” featured in All The Queen&apos;s Men.
-          </audio>
-        </li>
-      </ul>
-    </div>
-  </div>
-</article>
 
       </div>
 


### PR DESCRIPTION
## Summary
- remove the redundant nested slide wrapper from the Peacock & BET carousel entry so it sits correctly inside the placements track
- fold the Sistas and All The Queen's Men audio listings into the combined slide so the carousel keeps a single active item

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddb0ca2830832282f2a3ff3b647fe9