### PR TITLE
Align placement audio sources with updated mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,9 +378,9 @@
               <p class="placements-blurb">A one-line spotlight about this Challenge placement will go here to capture the grit and high stakes of the episode.</p>
               <ul class="placements-tracks">
                 <li>
-                  <span class="placements-track-description">The Challenge — “Get First Place” elimination recap cue</span>
-                  <audio controls preload="metadata" src="assets/audio/getfirstplace.mp3">
-                    Download the track “Get First Place” featured in MTV's The Challenge.
+                  <span class="placements-track-description">The Challenge — “Drawing Conclusions” elimination recap cue</span>
+                  <audio controls preload="metadata" src="assets/audio/drawingconclusions.mp3">
+                    Download the track “Drawing Conclusions” featured in MTV's The Challenge.
                   </audio>
                 </li>
               </ul>
@@ -404,9 +404,9 @@
               <p class="placements-blurb">A quick note about the Jersey Shore Family Vacation episode will summarize how the cue amps the boardwalk drama.</p>
               <ul class="placements-tracks">
                 <li>
-                  <span class="placements-track-description">Jersey Shore Family Vacation — “Little Bird” house party cue</span>
-                  <audio controls preload="metadata" src="assets/audio/littlebird.mp3">
-                    Download the track “Little Bird” featured in Jersey Shore Family Vacation.
+                  <span class="placements-track-description">Jersey Shore Family Vacation — “All In Together Now” boardwalk bash cue</span>
+                  <audio controls preload="metadata" src="assets/audio/allintogethernow.mp3">
+                    Download the track “All In Together Now” featured in Jersey Shore Family Vacation.
                   </audio>
                 </li>
               </ul>
@@ -430,9 +430,9 @@
               <p class="placements-blurb">A glamorous sentence about the Drag Race placement will live here, nodding to the runway moment the cue underscores.</p>
               <ul class="placements-tracks">
                 <li>
-                  <span class="placements-track-description">RuPaul&apos;s Drag Race — “Urbana Prolific” runway reveal cue</span>
-                  <audio controls preload="metadata" src="assets/audio/urbanaprolific.mp3">
-                    Download the track “Urbana Prolific” featured in RuPaul&apos;s Drag Race.
+                  <span class="placements-track-description">RuPaul&apos;s Drag Race — “Carried Away” runway reveal cue</span>
+                  <audio controls preload="metadata" src="assets/audio/carriedaway.mp3">
+                    Download the track “Carried Away” featured in RuPaul&apos;s Drag Race.
                   </audio>
                 </li>
               </ul>
@@ -456,9 +456,9 @@
               <p class="placements-blurb">A single-sentence note about the Somebody Feed Phil segment will go here to hint at the travelogue flavor.</p>
               <ul class="placements-tracks">
                 <li>
-                  <span class="placements-track-description">Somebody Feed Phil — “Drawing Conclusions” city montage cue</span>
-                  <audio controls preload="metadata" src="assets/audio/drawingconclusions.mp3">
-                    Download the track “Drawing Conclusions” featured in Somebody Feed Phil.
+                  <span class="placements-track-description">Somebody Feed Phil — “Little Bird” city montage cue</span>
+                  <audio controls preload="metadata" src="assets/audio/littlebird.mp3">
+                    Download the track “Little Bird” featured in Somebody Feed Phil.
                   </audio>
                 </li>
               </ul>
@@ -482,9 +482,9 @@
               <p class="placements-blurb">A placeholder sentence about this Stranded with My Mother-in-Law feature will describe the tropical tension the cue scores.</p>
               <ul class="placements-tracks">
                 <li>
-                  <span class="placements-track-description">Stranded with My Mother-in-Law — “All In Together Now” challenge setup cue</span>
-                  <audio controls preload="metadata" src="assets/audio/allintogethernow.mp3">
-                    Download the track “All In Together Now” featured in Stranded with My Mother-in-Law.
+                  <span class="placements-track-description">Stranded with My Mother-in-Law — “Get First Place” challenge setup cue</span>
+                  <audio controls preload="metadata" src="assets/audio/getfirstplace.mp3">
+                    Download the track “Get First Place” featured in Stranded with My Mother-in-Law.
                   </audio>
                 </li>
               </ul>
@@ -513,6 +513,12 @@
                     Download the track “Sleek Chico” featured in Bravo&apos;s Below Deck.
                   </audio>
                 </li>
+                <li>
+                  <span class="placements-track-description">Below Deck — “Big Ocean” open-water montage cue</span>
+                  <audio controls preload="metadata" src="assets/audio/bigocean.mp3">
+                    Download the track “Big Ocean” featured in Bravo&apos;s Below Deck.
+                  </audio>
+                </li>
               </ul>
             </div>
           </div>
@@ -534,9 +540,9 @@
               <p class="placements-blurb">A single line about ATL Homicide will describe how the cue heightens the investigative stakes.</p>
               <ul class="placements-tracks">
                 <li>
-                  <span class="placements-track-description">ATL Homicide — “Big Ocean” case file montage cue</span>
-                  <audio controls preload="metadata" src="assets/audio/bigocean.mp3">
-                    Download the track “Big Ocean” featured in ATL Homicide.
+                  <span class="placements-track-description">ATL Homicide — “Urbana Prolific” case file montage cue</span>
+                  <audio controls preload="metadata" src="assets/audio/urbanaprolific.mp3">
+                    Download the track “Urbana Prolific” featured in ATL Homicide.
                   </audio>
                 </li>
               </ul>


### PR DESCRIPTION
## Summary
- update each placement audio source and descriptive text to match the latest cue assignments
- add the missing Below Deck "Big Ocean" option so both featured cues are available in the slide

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddb0cc1b188322be6798993013ab67