### PR TITLE
Replace placements carousel with static list

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,15 +312,8 @@
 <template id="tpl-projects">
   <section class="content-section projects" aria-labelledby="projects-heading">
     <h2 id="projects-heading">Broadcast Placements</h2>
-    <div class="placements-carousel" role="region" aria-roledescription="carousel" aria-label="Broadcast placement posters" data-interval="3200">
-      <div class="placements-track">
-        <article class="placements-slide is-active"
-                 id="placements-slide-peacock-bet"
-                 data-title="Peacock &amp; BET — Love Island USA, Sistas, All The Queen&apos;s Men"
-                 role="group"
-                 aria-roledescription="slide"
-                 aria-label="Peacock and BET placements for Love Island USA, Tyler Perry&apos;s Sistas, and All The Queen&apos;s Men."
-                 aria-hidden="false">
+    <div class="placements-list">
+      <article class="placements-card">
           <h3 class="placements-title">Peacock — Love Island USA</h3>
           <div class="placements-details">
             <figure class="placements-figure">
@@ -374,13 +367,7 @@
           </div>
         </article>
 
-        <article class="placements-slide"
-                 id="placements-slide-challenge"
-                 data-title="MTV — The Challenge"
-                 role="group"
-                 aria-roledescription="slide"
-                 aria-label="The Challenge key art with competitors poised for action."
-                 aria-hidden="true">
+        <article class="placements-card">
           <h3 class="placements-title">MTV — The Challenge</h3>
           <div class="placements-details">
             <figure class="placements-figure">
@@ -400,13 +387,7 @@
           </div>
         </article>
 
-        <article class="placements-slide"
-                 id="placements-slide-jersey-shore"
-                 data-title="MTV — Jersey Shore Family Vacation"
-                 role="group"
-                 aria-roledescription="slide"
-                 aria-label="Jersey Shore Family Vacation cast posing in matching track suits."
-                 aria-hidden="true">
+        <article class="placements-card">
           <h3 class="placements-title">MTV — Jersey Shore Family Vacation</h3>
           <div class="placements-details">
             <figure class="placements-figure">
@@ -426,13 +407,7 @@
           </div>
         </article>
 
-        <article class="placements-slide"
-                 id="placements-slide-rupaul"
-                 data-title="MTV — RuPaul&apos;s Drag Race"
-                 role="group"
-                 aria-roledescription="slide"
-                 aria-label="RuPaul in a sparkling gown flanked by Drag Race contestants."
-                 aria-hidden="true">
+        <article class="placements-card">
           <h3 class="placements-title">MTV — RuPaul&apos;s Drag Race</h3>
           <div class="placements-details">
             <figure class="placements-figure">
@@ -452,13 +427,7 @@
           </div>
         </article>
 
-        <article class="placements-slide"
-                 id="placements-slide-somebody-feed-phil"
-                 data-title="Netflix — Somebody Feed Phil"
-                 role="group"
-                 aria-roledescription="slide"
-                 aria-label="Somebody Feed Phil poster featuring Phil Rosenthal holding chopsticks."
-                 aria-hidden="true">
+        <article class="placements-card">
           <h3 class="placements-title">Netflix — Somebody Feed Phil</h3>
           <div class="placements-details">
             <figure class="placements-figure">
@@ -478,13 +447,7 @@
           </div>
         </article>
 
-        <article class="placements-slide"
-                 id="placements-slide-stranded"
-                 data-title="Netflix — Stranded with My Mother-in-Law"
-                 role="group"
-                 aria-roledescription="slide"
-                 aria-label="Stranded with My Mother-in-Law poster showing couples on a tropical shore."
-                 aria-hidden="true">
+        <article class="placements-card">
           <h3 class="placements-title">Netflix — Stranded with My Mother-in-Law</h3>
           <div class="placements-details">
             <figure class="placements-figure">
@@ -504,13 +467,7 @@
           </div>
         </article>
 
-        <article class="placements-slide"
-                 id="placements-slide-below-deck"
-                 data-title="Bravo — Below Deck"
-                 role="group"
-                 aria-roledescription="slide"
-                 aria-label="Below Deck cast standing on the deck of a luxury yacht."
-                 aria-hidden="true">
+        <article class="placements-card">
           <h3 class="placements-title">Bravo — Below Deck</h3>
           <div class="placements-details">
             <figure class="placements-figure">
@@ -536,13 +493,7 @@
           </div>
         </article>
 
-        <article class="placements-slide"
-                 id="placements-slide-atl-homicide"
-                 data-title="TV One — ATL Homicide"
-                 role="group"
-                 aria-roledescription="slide"
-                 aria-label="ATL Homicide detectives posed in front of the Atlanta skyline."
-                 aria-hidden="true">
+        <article class="placements-card">
           <h3 class="placements-title">TV One — ATL Homicide</h3>
           <div class="placements-details">
             <figure class="placements-figure">
@@ -561,15 +512,6 @@
             </div>
           </div>
         </article>
-
-      </div>
-
-      <div class="placements-controls">
-        <button class="placements-control placements-prev" type="button" aria-label="Previous placement">‹</button>
-        <div class="placements-dots" role="tablist" aria-label="Select placement"></div>
-        <button class="placements-control placements-next" type="button" aria-label="Next placement">›</button>
-      </div>
-      <p class="placements-status" aria-live="polite"></p>
     </div>
   </section>
 </template>

--- a/styles.css
+++ b/styles.css
@@ -149,12 +149,9 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 }
 
 /* Placements window */
-.content-section.projects .placements-carousel{display:flex; flex-direction:column; gap:12px; max-width:720px; margin:0 auto}
-.placements-track{border:2px solid var(--dark); border-radius:14px; background:linear-gradient(135deg, #fefefe, #e3e3e3); box-shadow:inset -2px -2px 0 rgba(0,0,0,.18); display:grid}
-.placements-slide{padding:18px 20px; display:none; flex-direction:column; gap:16px; grid-area:1/1}
-.placements-slide.is-active{display:flex; pointer-events:auto; animation:placements-slide-in 220ms ease both}
-.placements-slide:not(.is-active){pointer-events:none}
-.placements-slide h3{margin:0; font-size:20px}
+.content-section.projects .placements-list{display:flex; flex-direction:column; gap:24px; max-width:720px; margin:0 auto}
+.placements-card{border:2px solid var(--dark); border-radius:14px; background:linear-gradient(135deg, #fefefe, #e3e3e3); box-shadow:inset -2px -2px 0 rgba(0,0,0,.18); padding:18px 20px; display:flex; flex-direction:column; gap:16px}
+.placements-card h3{margin:0; font-size:20px}
 .placements-details{display:flex; flex-direction:column; gap:18px}
 .placements-copy{display:flex; flex-direction:column; gap:18px}
 .placements-blurb{margin:0}
@@ -168,32 +165,11 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
 .placements-tracklist{display:grid; gap:8px; padding:12px; border:1px solid var(--dark); border-radius:10px; background:rgba(255,255,255,.72)}
 .placements-tracklist h4{margin:0; font-size:16px}
 .placements-tracklist p{margin:0}
-.placements-controls{display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap}
-.placements-control{width:36px; height:36px; border:2px solid var(--dark); border-radius:50%; background:var(--accent); font-size:20px; line-height:1; cursor:pointer; display:grid; place-items:center; transition:background 150ms ease, transform 150ms ease}
-.placements-control:disabled{opacity:.4; cursor:default}
-.placements-control:hover:not(:disabled),
-.placements-control:focus-visible:not(:disabled){background:var(--accent-dim)}
-.placements-control:focus-visible{outline:2px dashed var(--titlebar); outline-offset:2px}
-.placements-dots{display:none}
-.placements-dot{padding:6px 12px; border:2px solid var(--dark); border-radius:999px; background:var(--win); cursor:pointer; font:inherit; font-size:12px; line-height:1.2; white-space:nowrap; transition:background 150ms ease, transform 150ms ease}
-.placements-dot.is-active{background:var(--accent); border-color:var(--accent-dim); transform:translateY(-1px)}
-.placements-dot:focus-visible{outline:2px dashed var(--titlebar); outline-offset:2px}
-.placements-status{margin:0; font-size:12px; text-align:center; color:var(--darker)}
-
-@keyframes placements-slide-in{
-  from{opacity:0; transform:translateX(6%);}
-  to{opacity:1; transform:translateX(0);}
-}
 
 @media (min-width:640px){
-  .placements-slide{gap:22px}
-  .placements-slide h3{font-size:22px}
+  .placements-card{gap:22px}
+  .placements-card h3{font-size:22px}
   .placements-details{flex-direction:row; align-items:flex-start; gap:24px}
   .placements-figure{flex:0 0 260px; max-width:320px}
   .placements-copy{flex:1}
-}
-
-@media (prefers-reduced-motion:reduce){
-  .placements-slide{transition:none; transform:none}
-  .placements-slide.is-active{animation:none}
 }


### PR DESCRIPTION
## Summary
- replace the broadcast placements carousel template with a simple stacked list and remove unused navigation markup
- simplify the placements styles so each card is always visible while keeping the existing interior layout

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68ddcaaf9748832283e53a3aa2fbbad0