### PR TITLE
Switch publishers window to carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,77 +232,69 @@
 <template id="tpl-publishers">
   <section class="content-section publishers" aria-labelledby="publishers-heading">
     <h2 id="publishers-heading">Publishers &amp; Libraries</h2>
-    <p class="publishers-intro">Samuel&apos;s catalog is represented by select publishers and curated libraries for sync licensing. Choose a partner to see a snapshot of their catalog focus and collaboration highlights.</p>
-    <div class="publisher-columns">
-      <div class="publisher-options" role="tablist" aria-orientation="vertical">
-        <button class="publisher-option is-active" role="tab" id="publisher-option-atlas" type="button" data-option="atlas" aria-controls="publisher-panel-atlas" aria-selected="true" aria-expanded="true">Atlas Audio Library</button>
-        <button class="publisher-option" role="tab" id="publisher-option-rosewood" type="button" data-option="rosewood" aria-controls="publisher-panel-rosewood" aria-selected="false" aria-expanded="false">Rosewood Scores</button>
-        <button class="publisher-option" role="tab" id="publisher-option-pulse" type="button" data-option="pulse" aria-controls="publisher-panel-pulse" aria-selected="false" aria-expanded="false">Pulse Sync</button>
+    <p class="publishers-intro">Samuel&apos;s catalog is represented by select publishers and curated libraries for sync licensing. Browse the carousel to meet the partners stewarding his work.</p>
+    <div class="publisher-carousel" role="region" aria-label="Publisher partners carousel">
+      <div class="publisher-viewport" tabindex="0" aria-live="polite">
+        <ul class="publisher-track">
+          <li class="publisher-slide" data-label="Universal Production Music">
+            <figure>
+              <img src="assets/img/universal.png" alt="Universal Production Music logo" />
+              <figcaption>
+                <h3>Universal Production Music</h3>
+                <p>Global powerhouse providing worldwide placement opportunities for Samuel&apos;s high-energy cues.</p>
+              </figcaption>
+            </figure>
+          </li>
+          <li class="publisher-slide" data-label="Soho Production Music">
+            <figure>
+              <img src="assets/img/soho.png" alt="Soho Production Music logo" />
+              <figcaption>
+                <h3>Soho Production Music</h3>
+                <p>London-based boutique with a focus on stylish grooves and character-rich instrumentals.</p>
+              </figcaption>
+            </figure>
+          </li>
+          <li class="publisher-slide" data-label="Paint the Noise">
+            <figure>
+              <img src="assets/img/paintthenoise.png" alt="Paint the Noise logo" />
+              <figcaption>
+                <h3>Paint the Noise</h3>
+                <p>Indie collective cultivating colorful beats and genre-blending collaborations.</p>
+              </figcaption>
+            </figure>
+          </li>
+          <li class="publisher-slide" data-label="Evolution Media Music">
+            <figure>
+              <img src="assets/img/evolutionmediamusic.png" alt="Evolution Media Music logo" />
+              <figcaption>
+                <h3>Evolution Media Music</h3>
+                <p>Trusted library for broadcast hits, pairing Samuel&apos;s hooks with premium series placements.</p>
+              </figcaption>
+            </figure>
+          </li>
+          <li class="publisher-slide" data-label="Epitome Music Library">
+            <figure>
+              <img src="assets/img/epitome.png" alt="Epitome Music Library logo" />
+              <figcaption>
+                <h3>Epitome Music Library</h3>
+                <p>Curators of modern orchestration and hybrid textures ideal for cinematic storytelling.</p>
+              </figcaption>
+            </figure>
+          </li>
+          <li class="publisher-slide" data-label="Get It Done Music">
+            <figure>
+              <img src="assets/img/getitdone.png" alt="Get It Done Music logo" />
+              <figcaption>
+                <h3>Get It Done Music</h3>
+                <p>Agile team delivering fast-turnaround briefs where Samuel&apos;s versatility shines.</p>
+              </figcaption>
+            </figure>
+          </li>
+        </ul>
       </div>
-      <div class="publisher-panels">
-        <div class="publisher-panel is-active" id="publisher-panel-atlas" data-option="atlas" role="tabpanel" aria-labelledby="publisher-option-atlas">
-          <figure class="publisher-hero">
-            <div class="publisher-logo" role="img" aria-label="Atlas Audio Library placeholder logo">
-              <svg viewBox="0 0 96 96" aria-hidden="true" focusable="false">
-                <defs>
-                  <linearGradient id="atlas-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                    <stop offset="0%" stop-color="#233979" />
-                    <stop offset="100%" stop-color="#5f8bd4" />
-                  </linearGradient>
-                </defs>
-                <rect x="4" y="4" width="88" height="88" rx="14" fill="url(#atlas-gradient)" />
-                <path d="M28 68L48 22l20 46h-9.6l-3.8-9H41.4l-3.8 9H28zm21-18.2h7.8L48 34.5l-6.8 15.3H49z" fill="#f6f8ff" />
-              </svg>
-            </div>
-            <figcaption>
-              <h3>Atlas Audio Library</h3>
-              <p>Electronic and hybrid orchestral collections with curated playlists across genres.</p>
-            </figcaption>
-          </figure>
-          <p>Atlas champions adventurous sound design that still feels grounded in melody. Their briefs lean into futuristic textures balanced with organic motifs, making them a natural fit for Samuel&apos;s hybrid compositions.</p>
-          <ul>
-            <li><strong>Collaboration highlights:</strong> Retrowave action cues, cinematic downtempo suites.</li>
-            <li><strong>Recent placements:</strong> Streaming series teasers, esports broadcast packages.</li>
-          </ul>
-        </div>
-        <div class="publisher-panel" id="publisher-panel-rosewood" data-option="rosewood" role="tabpanel" aria-labelledby="publisher-option-rosewood" hidden>
-          <figure class="publisher-hero">
-            <div class="publisher-logo" role="img" aria-label="Rosewood Scores placeholder logo">
-              <svg viewBox="0 0 96 96" aria-hidden="true" focusable="false">
-                <rect x="6" y="6" width="84" height="84" rx="18" fill="#6a2d44" />
-                <path d="M28 70c12-14 18-21 30-34l10 10-30 32h-10V70zm28-36c-2.4 0-4.4-2-4.4-4.4 0-2.4 2-4.4 4.4-4.4s4.4 2 4.4 4.4c0 2.4-2 4.4-4.4 4.4z" fill="#fbe7ef" />
-              </svg>
-            </div>
-            <figcaption>
-              <h3>Rosewood Scores</h3>
-              <p>Bespoke film and television placements with an ear for acoustic warmth.</p>
-            </figcaption>
-          </figure>
-          <p>Rosewood curates intimate ensembles and richly orchestrated themes, pairing Samuel&apos;s harmonic sensibility with directors seeking emotional nuance.</p>
-          <ul>
-            <li><strong>Collaboration highlights:</strong> Chamber string ballads, piano-led dramatic cues.</li>
-            <li><strong>Recent placements:</strong> Prestige docu-series, festival-bound short films.</li>
-          </ul>
-        </div>
-        <div class="publisher-panel" id="publisher-panel-pulse" data-option="pulse" role="tabpanel" aria-labelledby="publisher-option-pulse" hidden>
-          <figure class="publisher-hero">
-            <div class="publisher-logo" role="img" aria-label="Pulse Sync placeholder logo">
-              <svg viewBox="0 0 96 96" aria-hidden="true" focusable="false">
-                <rect x="8" y="8" width="80" height="80" rx="16" fill="#0c5a4a" />
-                <polyline points="20,58 34,46 42,54 54,34 62,42 76,30" fill="none" stroke="#9ef5d7" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
-              </svg>
-            </div>
-            <figcaption>
-              <h3>Pulse Sync</h3>
-              <p>Trailer-ready cues with flexible licensing options for fast-moving campaigns.</p>
-            </figcaption>
-          </figure>
-          <p>Pulse Sync thrives on high-impact statements and momentum. Samuel&apos;s layered builds and rhythmic hooks power their catalog&apos;s adrenaline-fueled playlists.</p>
-          <ul>
-            <li><strong>Collaboration highlights:</strong> Percussive hybrid anthems, tension risers.</li>
-            <li><strong>Recent placements:</strong> Game launch promos, blockbuster trailer spots.</li>
-          </ul>
-        </div>
+      <div class="publisher-controls">
+        <button class="publisher-nav" type="button" data-carousel-prev aria-label="Previous publisher">◀</button>
+        <button class="publisher-nav" type="button" data-carousel-next aria-label="Next publisher">▶</button>
       </div>
     </div>
     <p class="publishers-outro">For clearance details or custom requests, reach out via the contact window.</p>

--- a/script.js
+++ b/script.js
@@ -198,10 +198,172 @@ function initAboutWindow(windowEl){
   });
 }
 function initPublishersWindow(windowEl){
-  initTabbedWindow(windowEl, {
-    optionSelector: '.publisher-option',
-    panelSelector: '.publisher-panel'
+  if(!windowEl) return;
+  const carousel = windowEl.querySelector('.publisher-carousel');
+  const viewport = carousel?.querySelector('.publisher-viewport');
+  const track = carousel?.querySelector('.publisher-track');
+  const slides = track ? Array.from(track.children) : [];
+  if(!carousel || !viewport || !track || !slides.length) return;
+
+  const prevBtn = carousel.querySelector('[data-carousel-prev]');
+  const nextBtn = carousel.querySelector('[data-carousel-next]');
+  const prefersReducedMotion = typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)')
+    : { matches: false };
+
+  let currentIndex = 0;
+  let timerId = null;
+  let isHovering = false;
+  let hasFocus = false;
+  let paddingLeft = 0;
+
+  const totalSlides = slides.length;
+  slides.forEach((slide) => {
+    slide.setAttribute('role', 'group');
+    slide.setAttribute('aria-roledescription', 'slide');
   });
+
+  const recalcMetrics = () => {
+    const style = window.getComputedStyle(track);
+    paddingLeft = parseFloat(style.paddingLeft) || 0;
+  };
+
+  const setSlideVisibility = () => {
+    slides.forEach((slide, index) => {
+      const isActive = index === currentIndex;
+      slide.classList.toggle('is-active', isActive);
+      slide.setAttribute('aria-hidden', String(!isActive));
+    });
+  };
+
+  const updateViewportLabel = () => {
+    const label = slides[currentIndex]?.dataset.label || `Publisher ${currentIndex + 1}`;
+    viewport.setAttribute('aria-label', `${label} (${currentIndex + 1} of ${totalSlides})`);
+  };
+
+  const updateTransform = () => {
+    const activeSlide = slides[currentIndex];
+    if(!activeSlide) return;
+    const offset = Math.max(0, activeSlide.offsetLeft - paddingLeft);
+    track.style.transform = `translateX(-${offset}px)`;
+    setSlideVisibility();
+    updateViewportLabel();
+  };
+
+  const stopTimer = () => {
+    if(timerId !== null){
+      clearInterval(timerId);
+      timerId = null;
+    }
+  };
+
+  const shouldAutoPlay = () => {
+    return !prefersReducedMotion.matches && !isHovering && !hasFocus && !document.hidden;
+  };
+
+  const refreshTimer = () => {
+    stopTimer();
+    if(shouldAutoPlay()){
+      timerId = window.setInterval(() => {
+        setIndex((currentIndex + 1) % totalSlides, { fromTimer: true });
+      }, 6000);
+    }
+  };
+
+  const setIndex = (index, { fromTimer = false } = {}) => {
+    const normalized = (index + totalSlides) % totalSlides;
+    if(normalized === currentIndex && !fromTimer){
+      refreshTimer();
+      return;
+    }
+    currentIndex = normalized;
+    updateTransform();
+    if(!fromTimer){
+      refreshTimer();
+    }
+  };
+
+  const handleKeydown = (event) => {
+    const { key } = event;
+    if(key === 'ArrowRight' || key === 'ArrowDown'){
+      event.preventDefault();
+      setIndex(currentIndex + 1);
+    } else if(key === 'ArrowLeft' || key === 'ArrowUp'){
+      event.preventDefault();
+      setIndex(currentIndex - 1);
+    } else if(key === 'Home'){
+      event.preventDefault();
+      setIndex(0);
+    } else if(key === 'End'){
+      event.preventDefault();
+      setIndex(totalSlides - 1);
+    }
+  };
+
+  const handleMouseEnter = () => { isHovering = true; refreshTimer(); };
+  const handleMouseLeave = () => { isHovering = false; refreshTimer(); };
+  const handleFocusIn = () => { hasFocus = true; refreshTimer(); };
+  const handleFocusOut = (event) => {
+    if(!carousel.contains(event.relatedTarget)){
+      hasFocus = false;
+      refreshTimer();
+    }
+  };
+  const handleVisibilityChange = () => refreshTimer();
+  const handleMotionChange = () => refreshTimer();
+  const handleResize = () => {
+    recalcMetrics();
+    updateTransform();
+  };
+
+  const handlePrev = () => setIndex(currentIndex - 1);
+  const handleNext = () => setIndex(currentIndex + 1);
+
+  viewport.addEventListener('keydown', handleKeydown);
+  carousel.addEventListener('mouseenter', handleMouseEnter);
+  carousel.addEventListener('mouseleave', handleMouseLeave);
+  carousel.addEventListener('focusin', handleFocusIn);
+  carousel.addEventListener('focusout', handleFocusOut);
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+  if(typeof prefersReducedMotion.addEventListener === 'function'){
+    prefersReducedMotion.addEventListener('change', handleMotionChange);
+  } else if(typeof prefersReducedMotion.addListener === 'function'){
+    prefersReducedMotion.addListener(handleMotionChange);
+  }
+  window.addEventListener('resize', handleResize);
+  prevBtn?.addEventListener('click', handlePrev);
+  nextBtn?.addEventListener('click', handleNext);
+
+  recalcMetrics();
+  updateTransform();
+  refreshTimer();
+
+  const observer = new MutationObserver(() => {
+    if(!windowEl.isConnected){
+      cleanup();
+      observer.disconnect();
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  function cleanup(){
+    stopTimer();
+    viewport.removeEventListener('keydown', handleKeydown);
+    carousel.removeEventListener('mouseenter', handleMouseEnter);
+    carousel.removeEventListener('mouseleave', handleMouseLeave);
+    carousel.removeEventListener('focusin', handleFocusIn);
+    carousel.removeEventListener('focusout', handleFocusOut);
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    if(typeof prefersReducedMotion.removeEventListener === 'function'){
+      prefersReducedMotion.removeEventListener('change', handleMotionChange);
+    } else if(typeof prefersReducedMotion.removeListener === 'function'){
+      prefersReducedMotion.removeListener(handleMotionChange);
+    }
+    window.removeEventListener('resize', handleResize);
+    prevBtn?.removeEventListener('click', handlePrev);
+    nextBtn?.removeEventListener('click', handleNext);
+    observer.disconnect();
+  }
 }
 
 // Canonical initializer; keep legacy tab UI available if markup still uses it

--- a/styles.css
+++ b/styles.css
@@ -128,24 +128,26 @@ body{margin:0; font:14px/1 "Segoe UI", sans-serif; color:var(--text); background
   .about-options{min-width:140px}
 }
 /* Publishers window */
-.content-section.publishers .publisher-columns{display:flex; flex-direction:column; gap:16px}
-.content-section.publishers .publisher-panels{flex:1; min-width:0}
-.publisher-options{display:flex; flex-direction:column; gap:8px; align-self:flex-start}
-.publisher-option{padding:8px 12px; border:2px solid var(--dark); background:var(--win); text-align:left; cursor:pointer; font:inherit}
-.publisher-option.is-active{background:var(--accent); border-color:var(--accent-dim)}
-.publisher-option:focus-visible{outline:2px dashed var(--titlebar); outline-offset:2px}
-.publisher-panel{display:none}
-.publisher-panel.is-active{display:block}
-.publisher-hero{display:flex; gap:16px; align-items:center; margin:0 0 16px}
-.publisher-hero figcaption{margin:0}
-.publisher-hero h3{margin:0 0 4px}
-.publisher-logo{width:96px; height:96px; border:2px solid var(--dark); border-radius:16px; background:var(--light); display:grid; place-items:center; flex:0 0 auto; overflow:hidden; box-shadow:inset -2px -2px 0 rgba(0,0,0,0.2)}
-.publisher-logo svg{width:100%; height:100%}
 .publishers-intro, .publishers-outro{max-width:62ch}
+.publisher-carousel{margin-top:20px; display:flex; flex-direction:column; gap:12px}
+.publisher-viewport{position:relative; overflow:hidden; border:2px solid var(--dark); border-radius:18px; background:linear-gradient(145deg, #fefefe, #e4e4e4); box-shadow:inset -2px -2px 0 rgba(0,0,0,0.18)}
+.publisher-viewport:focus-visible{outline:2px dashed var(--titlebar); outline-offset:4px}
+.publisher-track{display:flex; gap:18px; list-style:none; margin:0; padding:24px; transition:transform 800ms cubic-bezier(.33,.11,.15,.99)}
+.publisher-slide{flex:0 0 clamp(240px, 60vw, 320px); display:flex; align-items:stretch}
+.publisher-slide figure{margin:0; display:flex; flex-direction:column; gap:12px; width:100%; transition:transform 400ms ease, box-shadow 400ms ease}
+.publisher-slide img{width:100%; height:auto; border-radius:14px; border:2px solid var(--dark); box-shadow:0 4px 12px rgba(0,0,0,.22)}
+.publisher-slide figcaption{display:flex; flex-direction:column; gap:6px}
+.publisher-slide h3{margin:0; font-size:18px}
+.publisher-slide p{margin:0; font-size:14px; line-height:1.45}
+.publisher-slide.is-active figure{transform:translateY(-6px); box-shadow:0 10px 20px rgba(0,0,0,.25)}
+.publisher-controls{display:flex; justify-content:center; gap:12px}
+.publisher-nav{width:40px; height:40px; border-radius:50%; border:2px solid var(--dark); background:var(--win); font-weight:700; cursor:pointer; display:flex; align-items:center; justify-content:center; box-shadow:inset -1px -1px 0 var(--light), inset 1px 1px 0 rgba(0,0,0,0.25)}
+.publisher-nav:focus-visible{outline:2px dashed var(--titlebar); outline-offset:2px}
+.publisher-nav:active{background:var(--accent)}
 
-@media (min-width:640px){
-  .content-section.publishers .publisher-columns{flex-direction:row; align-items:flex-start}
-  .publisher-options{min-width:200px}
+@media (prefers-reduced-motion: reduce){
+  .publisher-track{transition:none}
+  .publisher-slide figure{transition:none}
 }
 
 /* Placements window */


### PR DESCRIPTION
## Summary
- replace the publishers tab set with a six-tile carousel and accessible markup
- add carousel styling, animation cues, and reduced-motion fallbacks
- implement JavaScript to drive auto-advancing slides with cleanup on close

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddeb31a478832287278d93efdeee38